### PR TITLE
Add a missing parameter in ExplicitRungeKuttaMethod.__step__ method

### DIFF
--- a/runge_kutta_method.py
+++ b/runge_kutta_method.py
@@ -1243,7 +1243,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
         to RungeKuttaMethod, but also includes time-stepping and
         a few other functions.
     """
-    def __step__(self,f,t,u,dt,x=None,errest=False):
+    def __step__(self,f,t,u,dt,x=None,errest=False,use_butcher=False):
         """
             Take a time step on the ODE u'=f(t,u).
 


### PR DESCRIPTION
When executing the example examples/advectionSD.py, an error
occurs in the ExplicitRungeKuttaMethod because of a missing parameter
named use_butcher
