### PR TITLE
Port to Python 3

### DIFF
--- a/examples/convergence_example.py
+++ b/examples/convergence_example.py
@@ -1,6 +1,7 @@
 import nodepy.runge_kutta_method as rk
 import nodepy.convergence as cv
 from nodepy import ivp
+import matplotlib.pyplot as pl
 
 #Load some methods:
 rk4=rk.loadRKM('RK44')
@@ -15,3 +16,4 @@ myivp=ivp.load_ivp('test')
 T=[0.,5.]
 
 cv.ctest([rk4,SSP2,SSP104],myivp)
+pl.show()

--- a/examples/perf.py
+++ b/examples/perf.py
@@ -1,11 +1,13 @@
 """Runs a performance test over the non-stiff DETEST suite of problems"""
 from nodepy import *
+import matplotlib.pyplot as pl
 
 bs5=rk.loadRKM('BS5')
 f5=rk.loadRKM('Fehlberg45')
 dp5=rk.loadRKM('DP5')
 ivps=ivp.detest_suite()
 
-tols=map(lambda x:10**-x,range(4,10))
+tols=list(map(lambda x:10**-x,range(4,10)))
 
 conv.ptest([bs5,dp5,f5],ivps,tols)
+pl.show()

--- a/examples/plot_order_stars.py
+++ b/examples/plot_order_stars.py
@@ -1,16 +1,18 @@
 from nodepy.stability_function import pade_exp
 from nodepy.stability_function import plot_order_star
-import pylab as pl
+import matplotlib.pyplot as pl
+import numpy as np
 
-P=range(5)
-Q=range(5)
+P=list(range(5))
+Q=list(range(5))
 k=(5,4,4,0)
 j=(5,6,7,10)
 for ip in range(4):
     P[ip],Q[ip]=pade_exp(k[ip],j[ip])
-    plot_order_star(P[ip],Q[ip],subplot=(2,2,ip+1),bounds=[-10,10,-10,10])
+    plot_order_star(P[ip],Q[ip],bounds=[-10,10,-10,10])
     pl.hold(True)
     pl.plot(P[ip].r.real,P[ip].r.imag,'ok')
     pl.plot(Q[ip].r.real,Q[ip].r.imag,'ok')
     pl.hold(False)
     pl.title('k='+str(k[ip])+',j='+str(j[ip]))
+    pl.show()

--- a/examples/plot_trees.py
+++ b/examples/plot_trees.py
@@ -1,7 +1,8 @@
 import nodepy.rooted_trees as rt
-import pylab as pl
+import matplotlib.pyplot as pl
 
 rt.plot_all_trees(6)
 pl.suptitle('Rooted Trees of Order 6',fontsize=20)
 pl.suptitle('Titles are tree representations in Butcher notation',fontsize=12,y=0.05)
 pl.draw()
+pl.show()

--- a/nodepy/__init__.py
+++ b/nodepy/__init__.py
@@ -4,12 +4,12 @@ NodePy (Numerical ODE solvers in Python) is...
 
 __version__="0.6.1"
 
-import runge_kutta_method as rk
-import twostep_runge_kutta_method as tsrk
-import downwind_runge_kutta_method as dwrk
-import linear_multistep_method as lm
-import rooted_trees as rt
-import ivp
-import convergence as conv
-import low_storage_rk as lsrk
-import graph
+import nodepy.runge_kutta_method as rk
+import nodepy.twostep_runge_kutta_method as tsrk
+import nodepy.downwind_runge_kutta_method as dwrk
+import nodepy.linear_multistep_method as lm
+import nodepy.rooted_trees as rt
+import nodepy.ivp
+import nodepy.convergence as conv
+import nodepy.low_storage_rk as lsrk
+import nodepy.graph

--- a/nodepy/downwind_runge_kutta_method.py
+++ b/nodepy/downwind_runge_kutta_method.py
@@ -8,7 +8,7 @@ Class for Downwind Runge-Kutta methods, and various functions related to them.
 * Load a method::
 
     >>> dw2 = dwrk.opt_dwrk(8)
-    >>> print dw2 # doctest: +NORMALIZE_WHITESPACE
+    >>> print(dw2) # doctest: +NORMALIZE_WHITESPACE
     downwind Runge-Kutta Method
     <BLANKLINE>
      0.750 |  2.875         |         2.125
@@ -28,10 +28,11 @@ REFERENCES:
     [higueras2005,Ketcheson2010]_
 """
 from __future__ import division
-from general_linear_method import GeneralLinearMethod
-import runge_kutta_method as rk
+
 import numpy as np
-import snp
+import nodepy.snp as snp
+import nodepy.runge_kutta_method as rk
+from nodepy.general_linear_method import GeneralLinearMethod
 
 #=====================================================
 class DownwindRungeKuttaMethod(GeneralLinearMethod):
@@ -71,10 +72,10 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
         elif alpha is not None: #Initialize with Shu-Osher arrays
             A,At,b,bt=downwind_shu_osher_to_butcher(alpha,alphat,beta,betat)
         # Set Butcher arrays
-        if len(np.shape(A))==2: 
+        if len(np.shape(A))==2:
           self.A=A
           self.At=At
-        else: 
+        else:
           self.A =snp.array([A ]) #Fix for 1-stage methods
           self.At=snp.array([At])
         self.b=b;
@@ -84,7 +85,7 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
         self.info=description
         self.underlying_method=rk.RungeKuttaMethod(self.A-self.At,self.b-self.bt)
 
-    def __repr__(self): 
+    def __repr__(self):
         """
         Pretty-prints the Butcher array in the form:
           |   |
@@ -92,7 +93,7 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
         ___________
           | b | bt
         """
-        from utils import shortstring
+        from nodepy.utils import shortstring
         c = [shortstring(ci) for ci in self.c]
         clenmax = max([len(ci) for ci in c])
         A = [shortstring(ai) for ai in self.A.reshape(-1)]
@@ -114,7 +115,7 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
             for j in range(len(self)):
                 ss=shortstring(self.A[i,j])
                 s+=ss.ljust(colmax+1)
-            s+=' | '    
+            s+=' | '
             for j in range(len(self)):
                 ss=shortstring(self.At[i,j])
                 s+=ss.ljust(colmax+1)
@@ -127,32 +128,32 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
         for j in range(len(self)):
             s+=' '*(colmax-len(bt[j])+1)+bt[j]
         return s
- 
+
     def __len__(self):
         """
             The length of the method is the number of stages.
         """
-        return np.size(self.A,0) 
+        return np.size(self.A,0)
 
     def order(self,tol=1.e-13):
-        r""" 
+        r"""
             Return the order of a Downwind Runge-Kutta method.
         """
         return self.underlying_method.order(tol)
 
     def absolute_monotonicity_radius(self,acc=1.e-10,rmax=200,
                     tol=3.e-16):
-        r""" 
+        r"""
             Returns the radius of absolute monotonicity
             of a Runge-Kutta method.
         """
-        from utils import bisect
-        
+        from nodepy.utils import bisect
+
         r=bisect(0,rmax,acc,tol,self.is_absolutely_monotonic)
         return r
 
     def is_absolutely_monotonic(self,r,tol):
-        r""" Returns 1 if the downwind Runge-Kutta method is 
+        r""" Returns 1 if the downwind Runge-Kutta method is
             absolutely monotonic at $z=-r$.
 
             The method is absolutely monotonic if $(I+rK+rKt)^{-1}$ exists
@@ -169,11 +170,11 @@ class DownwindRungeKuttaMethod(GeneralLinearMethod):
 
         """
         m=len(self)
-        K  =np.hstack([np.vstack([self.A  ,self.b ]),np.zeros([m+1,1])])
-        Kt =np.hstack([np.vstack([self.At ,self.bt]),np.zeros([m+1,1])])
+        K  =np.hstack([np.vstack([self.A  ,self.b ]),np.zeros([m+1,1])]).astype(np.float64)
+        Kt =np.hstack([np.vstack([self.At ,self.bt]),np.zeros([m+1,1])]).astype(np.float64)
         X=np.eye(len(self)+1) + r*(K+Kt)
         beta =r*np.linalg.solve(X, K)
-        betat=r*np.linalg.solve(X,Kt)
+        betat=r*np.linalg.solve(X, Kt)
         ech=np.linalg.solve(X,np.ones(m+1))
         if min(beta.min(),betat.min(),ech.min())<-tol:
             return 0
@@ -196,7 +197,7 @@ def opt_dwrk(r):
 
 def downwind_shu_osher_to_butcher(alpha,alphat,beta,betat):
     r""" Accepts a Shu-Osher representation of a downwind Runge-Kutta
-        method and returns the Butcher coefficients 
+        method and returns the Butcher coefficients
 
         \\begin{align*}
         A  = & (I-\\alpha_0-\\alphat_0)^{-1} \\beta_0 \\\\
@@ -204,7 +205,7 @@ def downwind_shu_osher_to_butcher(alpha,alphat,beta,betat):
         b = & \\beta_1 + (\\alpha_1 + \\alphat_1) * A
         \\end{align*}
 
-        **References**:  
+        **References**:
              #. [gottlieb2009]_
     """
     m=np.size(alpha,1)

--- a/nodepy/general_linear_method.py
+++ b/nodepy/general_linear_method.py
@@ -1,11 +1,11 @@
-from ode_solver import ODESolver
-import rooted_trees as rt
+from nodepy.ode_solver import ODESolver
+import nodepy.rooted_trees as rt
 
 #=====================================================
 class GeneralLinearMethod(ODESolver):
 #=====================================================
     """ General class for multstage, multistep methods.
-    
+
         This is a pure virtual class; only its child classes
         should be instantiated.
     """
@@ -14,7 +14,7 @@ class GeneralLinearMethod(ODESolver):
 
     def order_conditions(self,p):
         """
-        Generate a list of order conditions up to order p 
+        Generate a list of order conditions up to order p
         """
 
         forest=rt.list_trees(0)

--- a/nodepy/ivp.py
+++ b/nodepy/ivp.py
@@ -18,7 +18,7 @@ This module implements the initial value problem as a class.
 
     # Integrate this problem with a Runge-Kutta method
     >>> rk4 = rk.loadRKM('RK44')
-    >>> t,y = rk4(myivp)
+    >>> t, y = rk4(myivp)
     >>> y[-1][0] # doctest: +ELLIPSIS
     2.06115362252...e-09
 
@@ -28,6 +28,8 @@ This module implements the initial value problem as a class.
     # Load a few stiff problems
     >>> problems = detest_stiff_suite()
 """
+from __future__ import print_function
+
 import numpy as np
 
 class IVP(object):
@@ -43,7 +45,7 @@ class IVP(object):
             exact: a function that takes one argument (t) and returns
                    the exact solution (Should we make this a function of
                    u0 as well?)
-            dt0: The default initial timestep when a variable step size 
+            dt0: The default initial timestep when a variable step size
                  integrator is used.
             Any other problem-specific parameters.
 
@@ -67,15 +69,15 @@ def load_ivp(ivpname='All'):
 
         >>> from nodepy import ivp
         >>> ivps = ivp.load_ivp('all')
-        >>> for problem in ivps.itervalues():
-        ...     print "%s: %s" % (problem.name, problem.description)
-        vdp: Van der Pol oscillator with epsilon = 1/10.
-        ode2: 
-        2odes: 
-        ode1: 
+        >>> for problem in sorted(ivps.values(), key=lambda x: x.name):
+        ...     print("{}: {}".format(problem.name, problem.description).rstrip())
+        2odes:
         nlsin: A simple nonlinear scalar problem
-        zoltan: The linear scalar test problem with abs value
+        ode1:
+        ode2:
         test: Dahlquist's test problem; $f(y) = \lambda y$
+        vdp: Van der Pol oscillator with epsilon = 1/10.
+        zoltan: The linear scalar test problem with abs value
     """
     ivps = {}
 
@@ -145,10 +147,10 @@ def detest(testkey):
             standard, and although there are certain dangers in accepting
             any particular set of problems as a universal standard, it
             is nevertheless sometimes useful to try a new method on this
-            test set due to the availability of published results for 
+            test set due to the availability of published results for
             many existing methods.
-        
-        Reference: [enright1987]_ 
+
+        Reference: [enright1987]_
     """
     import numpy as np
     ivp=IVP()
@@ -215,7 +217,7 @@ def detest(testkey):
         e=np.arange(1,11); e[-1]=0.
         ivp.L_rhs = np.diag(-e)+np.diag(e[:-1],-1);
         ivp.rhs = lambda t,u: np.dot(ivp.L_rhs,u)
-        ivp.dt0 = 1.e-2    
+        ivp.dt0 = 1.e-2
     elif testkey=='C3':
         ivp.u0=np.zeros(10); ivp.u0[0]=1.
         ivp.T=20.
@@ -229,10 +231,17 @@ def detest(testkey):
         e=np.ones(51)
         ivp.L_rhs = np.diag(-2*e)+np.diag(e[:-1],-1)+np.diag(e[:-1],1);
         ivp.rhs = lambda t,u: np.dot(ivp.L_rhs,u)
-        ivp.dt0 = 1.e-2     
+        ivp.dt0 = 1.e-2
     elif testkey=='C5':
         ivp.u0=np.zeros(30)
-	ivp.u0 = np.array([3.42947415189,3.35386959711,1.35494901715,6.64145542550,5.97156957878,2.18231499728,11.2630437207,14.6952576794,6.27960525067,-30.1552268759,1.65699966404,1.43785752721,-21.1238353380,28.4465098142,15.3882659679,-.557160570446,.505696783289,.230578543901,-.415570776342,.365682722812,.169143213293,-.325325669158,.189706021964,.0877265322780,-.0240476254170,-.287659532608,-.117219543175,-.176860753121,-.216393453025,-.0148647893090])	
+        ivp.u0 = np.array([3.42947415189, 3.35386959711, 1.35494901715,
+            6.64145542550, 5.97156957878, 2.18231499728, 11.2630437207,
+            14.6952576794, 6.27960525067, -30.1552268759, 1.65699966404,
+            1.43785752721, -21.1238353380, 28.4465098142, 15.3882659679,
+            -0.557160570446, 0.505696783289, 0.230578543901, -0.415570776342,
+            0.365682722812, 0.169143213293, -0.325325669158, 0.189706021964,
+            0.0877265322780, -0.0240476254170, -0.287659532608, -0.117219543175,
+            -0.176860753121,  -0.216393453025, -0.0148647893090])
         ivp.T=20.
         ivp.rhs = _C5rhs
         ivp.dt0 = 1.e-2
@@ -383,37 +392,37 @@ def _B4rhs(t,u):
     return du
 def _C5rhs(t,u):
     r = np.zeros(5); u1 = np.zeros(15); u2 = np.zeros(15); y1 = np.zeros((3,5)); y2 = np.zeros((3,5)); d = np.zeros((5,5)); du=np.zeros(30); ynew1 = np.zeros((3,5)); ynew2 = np.zeros((3,5));
-    k2 = 2.95912208286; m0 = 1.00000597682; 
+    k2 = 2.95912208286; m0 = 1.00000597682;
     m = np.array([.000954786104043,.000285583733151,.0000437273164546,.0000517759138449,.00000277777777778])
     k=0
     for j in range(0,5):
-	for i in range(0,3):
-	    y1[i][j] = u[k]
-	    y2[i][j] = u[k+15]
-	    k+=1
+        for i in range(0,3):
+            y1[i][j] = u[k]
+            y2[i][j] = u[k+15]
+            k+=1
 
     for j in range(0,5):
-	r[j] = np.sqrt(y1[0][j]**2+y1[1][j]**2+y1[2][j]**2)
+        r[j] = np.sqrt(y1[0][j]**2+y1[1][j]**2+y1[2][j]**2)
 
     for k in range(0,5):
-	for j in range(0,5):
-	    d[k][j] = np.sqrt((y1[0][k]-y1[0][j])**2+(y1[1][k]-y1[1][j])**2+(y1[2][k]-y1[2][j])**2)
-	      
+        for j in range(0,5):
+            d[k][j] = np.sqrt((y1[0][k]-y1[0][j])**2+(y1[1][k]-y1[1][j])**2+(y1[2][k]-y1[2][j])**2)
+
     for j  in range(0,5):
-	for i in range(0,3):
-	    term=0.;
-	    for k in range(0,5):
-		if (k != j):
-		    term = term+m[k]*((y1[i][k]-y1[i][j])/d[j][k]**3 - y1[i][k]/r[k]**3)
-	    ynew1[i][j] = y2[i][j] 
-	    ynew2[i][j] = k2*(-(m0+m[j])*y1[i][j]/r[j]**3+term)
+        for i in range(0,3):
+            term=0.;
+            for k in range(0,5):
+                if (k != j):
+                    term = term+m[k]*((y1[i][k]-y1[i][j])/d[j][k]**3 - y1[i][k]/r[k]**3)
+            ynew1[i][j] = y2[i][j]
+            ynew2[i][j] = k2*(-(m0+m[j])*y1[i][j]/r[j]**3+term)
     k=0
     for j in range(0,5):
-	for i in range(0,3):
-	    du[k] = ynew1[i][j]
-	    du[k+15] = ynew2[i][j] 
-	    k+=1
-    
+        for i in range(0,3):
+            du[k] = ynew1[i][j]
+            du[k+15] = ynew2[i][j]
+            k+=1
+
     return du
 
 def detest_suite():
@@ -460,7 +469,8 @@ def detest_stiff(testkey):
         ivp.T=1.
         ivp.rhs = _A4rhs_stiff
         ivp.dt0 = 1.e-5
-    else: print 'Unknown Detest problem; returning empty IVP'
+    else:
+        print('Unknown Detest problem; returning empty IVP')
     return ivp
 
 def _A2rhs_stiff(t,u):

--- a/nodepy/ivp.py
+++ b/nodepy/ivp.py
@@ -381,7 +381,7 @@ def _F4rhs(t,u):
 def _F5rhs(t,u):
     du=np.zeros(1)
     c=np.sum([i**(4./3) for i in range(1,20)])
-    du[0] = 4./3/c * np.sum([(t-i+0j)**(4./3) for i in range(1,20)])*u[0]
+    du[0] = 4./3/c * np.sum([(t-i+0j)**(4./3) for i in range(1,20)]).real*u[0]
     return du
 
 def _B4rhs(t,u):

--- a/nodepy/linear_multistep_method.py
+++ b/nodepy/linear_multistep_method.py
@@ -1,7 +1,7 @@
 """
 **Examples**::
 
-    >>> import linear_multistep_method as lm
+    >>> import nodepy.linear_multistep_method as lm
     >>> ab3=lm.Adams_Bashforth(3)
     >>> ab3.order()
     3
@@ -25,11 +25,12 @@
     <matplotlib.figure.Figure object at 0x...>
 
 """
-from general_linear_method import GeneralLinearMethod
+from __future__ import print_function
+
 import numpy as np
 import sympy
-import snp
-
+import nodepy.snp as snp
+from nodepy.general_linear_method import GeneralLinearMethod
 
 
 #=====================================================
@@ -45,7 +46,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
         Notes: Representation follows Hairer & Wanner p. 368, NOT Butcher.
 
-        **References**:  
+        **References**:
             #. [hairer1993]_ Chapter III
             #. [butcher2003]_
     """
@@ -88,15 +89,15 @@ class LinearMultistepMethod(GeneralLinearMethod):
         `\sigma(z) = \sum_{j=0}^k \beta_k z^k`
 
         **Examples**::
-            
+
             >>> from nodepy import lm
             >>> ab5 = lm.Adams_Bashforth(5)
             >>> rho,sigma = ab5.characteristic_polynomials()
-            >>> print rho
+            >>> print(rho)
                5     4
             1 x - 1 x
 
-            >>> print sigma
+            >>> print(sigma)
                   4         3         2
             2.64 x - 3.853 x + 3.633 x - 1.769 x + 0.3486
 
@@ -110,7 +111,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
     def order(self,tol=1.e-10):
         r""" Return the order of the local truncation error of a linear multistep method.
-        
+
         **Examples**::
 
             >>> from nodepy import lm
@@ -126,7 +127,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
                 return p
 
     def _satisfies_order_conditions(self,p,tol):
-        """ Return True if the linear multistep method satisfies 
+        """ Return True if the linear multistep method satisfies
             the conditions of order p (only) """
         ii=snp.arange(len(self.alpha))
         return abs(sum(ii**p*self.alpha-p*self.beta*ii**(p-1)))<tol
@@ -145,23 +146,23 @@ class LinearMultistepMethod(GeneralLinearMethod):
         **Example**::
 
             >>> from nodepy import lm
-            >>> print lm.Adams_Bashforth(2).latex()
+            >>> print(lm.Adams_Bashforth(2).latex())
             \begin{align} y_{n + 2} - y_{n + 1} = \frac{3}{2}h f(y_{n + 1}) - \frac{1}{2}h f(y_{n})\end{align}
 
         """
         from sympy import symbols, latex
         n = symbols('n')
-        from snp import printable
+        from nodepy.snp import printable
         k = len(self)
         alpha_terms = []
         beta_terms = []
         for i in range(k+1):
             subscript = latex(n+k-i)
             if self.alpha[k-i] != 0:
-                alpha_terms.append(printable(self.alpha[k-i],return_one=False) 
+                alpha_terms.append(printable(self.alpha[k-i],return_one=False)
                                    + ' y_{'+subscript+'}')
             if self.beta[k-i] != 0:
-                beta_terms.append(printable(self.beta[k-i],return_one=False) 
+                beta_terms.append(printable(self.beta[k-i],return_one=False)
                                   +  'h f(y_{'+subscript+'})')
         lhs = ' + '.join(alpha_terms)
         rhs = ' + '.join(beta_terms)
@@ -173,7 +174,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
         r""" Return the SSP coefficient of the method.
 
          The SSP coefficient is given by
-        
+
         `\min_{0 \le j < k} -\alpha_k/beta_k`
 
         if `\alpha_j<0` and `\beta_j>0` for all `j`, and is equal to
@@ -191,16 +192,16 @@ class LinearMultistepMethod(GeneralLinearMethod):
             >>> bdf2.ssp_coefficient()
             0
         """
-        if np.any(self.alpha[:-1]>0) or np.any(self.beta<0): 
+        if np.any(self.alpha[:-1]>0) or np.any(self.beta<0):
             return 0
 
-        return min([-self.alpha[j]/self.beta[j] 
+        return min([-self.alpha[j]/self.beta[j]
                     for j in range(len(self.alpha)-1) if self.beta[j]!=0])
 
 
     def plot_stability_region(self,N=100,bounds=None,color='r',filled=True, alpha=1.,
                               to_file=False,longtitle=False):
-        r""" 
+        r"""
             The region of absolute stability of a linear multistep method is
             the set
 
@@ -214,7 +215,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
             `\{z | z=\rho(\exp(i\theta))/\sigma(\exp(i\theta)), 0\le \theta \le 2*\pi \}`
 
-            Here `\rho` and `\sigma` are the characteristic polynomials 
+            Here `\rho` and `\sigma` are the characteristic polynomials
             of the method.
 
             References:
@@ -281,7 +282,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
             `\{z | z=\rho(\exp(i\theta))/\sigma(\exp(i\theta)), 0\le \theta \le 2*\pi \}`
 
-            where `\rho` and `\sigma` are the characteristic polynomials 
+            where `\rho` and `\sigma` are the characteristic polynomials
             of the method.
 
             References:
@@ -309,7 +310,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
             `\{z | z=\rho(\exp(i\theta))/\sigma(\exp(i\theta)), 0\le \theta \le 2*\pi \}`
 
-            where `\rho` and `\sigma` are the characteristic polynomials 
+            where `\rho` and `\sigma` are the characteristic polynomials
             of the method.
 
             References:
@@ -324,10 +325,10 @@ class LinearMultistepMethod(GeneralLinearMethod):
 
     def A_alpha_stability(self, N=1000, tol=1.e-14):
         r"""Angle of `A(\alpha)`-stability.
-        
+
         The result is given in degrees.  The result is only accurate to
         about 1 degree, so we round down.
-        
+
         **Examples**:
 
             >>> from nodepy import lm
@@ -338,7 +339,7 @@ class LinearMultistepMethod(GeneralLinearMethod):
         from math import atan2, floor
 
         z = self._boundary_locus(N)
-        rad = map(atan2,np.imag(z),np.real(z))
+        rad = list(map(atan2,np.imag(z),np.real(z)))
         rad = np.mod(np.array(rad),2*np.pi)
 
         return min(int(floor(np.min(np.abs(np.where(np.real(z)<-tol,rad,1.e99)-np.pi))/np.pi*180)),90)
@@ -375,7 +376,7 @@ class AdditiveLinearMultistepMethod(GeneralLinearMethod):
         The method takes the form
 
         `\alpha_k y_{n+k} + \alpha_{k-1} y_{n+k-1} + ... + \alpha_0 y_n
-        = h ( \beta_k f_{n+k} + ... + \beta_0 f_n 
+        = h ( \beta_k f_{n+k} + ... + \beta_0 f_n
         + \gamma_k f_{n+k} + ... + \gamma_0 f_n )`
 
         Methods are automatically normalized so that \alpha_k=1.
@@ -424,7 +425,7 @@ class AdditiveLinearMultistepMethod(GeneralLinearMethod):
 
 
     def plot_imex_stability_region(self,N=100,color='r',filled=True, alpha=1.,fignum=None):
-        r""" 
+        r"""
             **Input**: (all optional)
                 - N       -- Number of gridpoints to use in each direction
                 - bounds  -- limits of plotting region
@@ -479,7 +480,7 @@ class AdditiveLinearMultistepMethod(GeneralLinearMethod):
             if np.abs(f[-1]-f[-2]) < epsilon:
                 return f[-1]
             if len(f)>100:
-                print f
+                print(f)
                 raise Exception('Unable to compute stiff damping factor: slow convergence')
 
 
@@ -515,19 +516,19 @@ def _root_condition(p,tol=1.e-13):
 #======================================================
 
 def Adams_Bashforth(k):
-    r""" 
+    r"""
     Construct the k-step, Adams-Bashforth method.
     The methods are explicit and have order k.
     They have the form:
 
     `y_{n+1} = y_n + h \sum_{j=0}^{k-1} \beta_j f(y_n-k+j+1)`
 
-    They are generated using equations (1.5) and (1.7) from 
+    They are generated using equations (1.5) and (1.7) from
     [hairer1993]_ III.1, along with the binomial expansion.
 
     **Examples**::
 
-        >>> import linear_multistep_method as lm
+        >>> import nodepy.linear_multistep_method as lm
         >>> ab3=lm.Adams_Bashforth(3)
         >>> ab3.order()
         3
@@ -564,7 +565,7 @@ def Nystrom(k):
 
     `y_{n+1} = y_{n-1} + h \sum_{j=0}^{k-1} \beta_j f(y_n-k+j+1)`
 
-    They are generated using equations (1.13) and (1.7) from 
+    They are generated using equations (1.13) and (1.7) from
     [hairer1993]_ III.1, along with the binomial expansion
     and the relation in exercise 4 on p. 367.
 
@@ -574,7 +575,7 @@ def Nystrom(k):
 
     **Examples**::
 
-        >>> import linear_multistep_method as lm
+        >>> import nodepy.linear_multistep_method as lm
         >>> nys3=lm.Nystrom(6)
         >>> nys3.order()
         6
@@ -608,20 +609,20 @@ def Nystrom(k):
     return LinearMultistepMethod(alpha,beta,name=name,shortname='Nys'+str(k))
 
 def Adams_Moulton(k):
-    r""" 
+    r"""
         Construct the k-step, Adams-Moulton method.
         The methods are implicit and have order k+1.
         They have the form:
 
         `y_{n+1} = y_n + h \sum_{j=0}^{k} \beta_j f(y_n-k+j+1)`
 
-        They are generated using equation (1.9) and the equation in 
-        Exercise 3 from Hairer & Wanner III.1, along with the binomial 
+        They are generated using equation (1.9) and the equation in
+        Exercise 3 from Hairer & Wanner III.1, along with the binomial
         expansion.
 
         **Examples**::
 
-            >>> import linear_multistep_method as lm
+            >>> import nodepy.linear_multistep_method as lm
             >>> am3=lm.Adams_Moulton(3)
             >>> am3.order()
             4
@@ -655,13 +656,13 @@ def Milne_Simpson(k):
 
         `y_{n+1} = y_{n-1} + h \sum_{j=0}^{k} \beta_j f(y_n-k+j+1)`
 
-        They are generated using equation (1.15), the equation in 
+        They are generated using equation (1.15), the equation in
         Exercise 3, and the relation in exercise 4, all from Hairer & Wanner
         III.1, along with the binomial expansion.
 
         **Examples**::
 
-            >>> import linear_multistep_method as lm
+            >>> import nodepy.linear_multistep_method as lm
             >>> ms3=lm.Milne_Simpson(3)
             >>> ms3.order()
             4
@@ -691,7 +692,7 @@ def Milne_Simpson(k):
     return LinearMultistepMethod(alpha,beta,name=name,shortname='MS'+str(k))
 
 def backward_difference_formula(k):
-    r""" 
+    r"""
         Construct the k-step backward differentiation method.
         The methods are implicit and have order k.
         They have the form:
@@ -703,7 +704,7 @@ def backward_difference_formula(k):
 
         **Examples**::
 
-            >>> import linear_multistep_method as lm
+            >>> import nodepy.linear_multistep_method as lm
             >>> bdf4=lm.backward_difference_formula(4)
             >>> bdf4.A_alpha_stability()
             73
@@ -733,7 +734,7 @@ def elm_ssp2(k):
 
     **Examples**::
 
-        >>> import linear_multistep_method as lm
+        >>> import nodepy.linear_multistep_method as lm
         >>> lm10=lm.elm_ssp2(10)
         >>> lm10.ssp_coefficient()
         8/9
@@ -755,7 +756,7 @@ def sand_cc(s):
 
     **Examples**::
 
-        >>> import linear_multistep_method as lm
+        >>> import nodepy.linear_multistep_method as lm
         >>> cc4 = lm.sand_cc(4)
         >>> cc4.order()
         10
@@ -790,7 +791,7 @@ def sand_cc(s):
         beta[j] = tau_product**2
         alpha[j] = 2*beta[j]*tau_sum
     return LinearMultistepMethod(alpha,beta,'Sand circle-contractive')
-        
+
 def arw2(gam,c):
     r"""Returns the second order IMEX additive multistep method based on the
     parametrization in Section 3.2 of Ascher, Ruuth, & Spiteri.  The parameters
@@ -812,7 +813,7 @@ def arw2(gam,c):
         1
         >>> CNLF.method2.ssp_coefficient()
         0
-        >>> print CNLF.stiff_damping_factor() #doctest: +ELLIPSIS
+        >>> print(CNLF.stiff_damping_factor()) #doctest: +ELLIPSIS
         0.999...
     """
     half = sympy.Rational(1,2)
@@ -823,7 +824,7 @@ def arw2(gam,c):
 
 
 def loadLMM(which='All'):
-    """ 
+    """
     Load a set of standard linear multistep methods for testing.
 
     **Examples**::

--- a/nodepy/loadmethod.py
+++ b/nodepy/loadmethod.py
@@ -11,9 +11,10 @@ Load some high-order RK pairs.
     "Feagin's 12(10) pair"
 
 """
-import numpy as np
-from nodepy import rk
 import os
+import numpy as np
+
+from nodepy import rk
 
 path = os.path.dirname(os.path.realpath(__file__))
 path = os.path.join(path,'method_coefficients')

--- a/nodepy/loadmethod.py
+++ b/nodepy/loadmethod.py
@@ -21,20 +21,20 @@ path = os.path.join(path,'method_coefficients')
 
 def method_name_and_stages(file_name):
     if ((file_name=='rk108.txt')):
-	name=r"Feagin's 10(8) pair"
-	stages=20
+        name=r"Feagin's 10(8) pair"
+        stages=20
     if ((file_name=='rk108curtis.txt')):
-	name=r"Curtis' 10(8) pair"
-	stages=21
+        name=r"Curtis' 10(8) pair"
+        stages=21
     if ((file_name=='rk1210.txt')):
         name=r"Feagin's 12(10) pair"
-	stages=25
+        stages=25
     if ((file_name=='rk129hiroshi.txt')):
         name=r"Hiroshi's 12(9) pair"
-	stages=29
+        stages=29
     if ((file_name=='rk1412.txt')):
-	name=r"Feagin's 14(12) pair"
-	stages=35
+        name=r"Feagin's 14(12) pair"
+        stages=35
     return name, stages
 
 def load_rk_from_file(file_name='rk1210.txt', load_pair=True):
@@ -54,7 +54,7 @@ def load_rk_from_file(file_name='rk1210.txt', load_pair=True):
             current_array = 'b'
         elif words[-1]=='c[k]':
             current_array = 'c'
-	elif words[-1]=='bhat[k]':
+        elif words[-1]=='bhat[k]':
             current_array = 'bhat'
         elif words[-1]=='A[k,j]':
             current_array = 'A'
@@ -63,7 +63,7 @@ def load_rk_from_file(file_name='rk1210.txt', load_pair=True):
             k = int(words[0])
             if current_array == 'b':
                 b[k] = float(words[1])
-	    elif current_array =='bhat':
+            elif current_array =='bhat':
                 bhat[k] = float(words[1])
             elif current_array == 'A':
                 j = int(words[1])

--- a/nodepy/oc_butcher.py
+++ b/nodepy/oc_butcher.py
@@ -1,10 +1,13 @@
+from __future__ import print_function
+
 def order(rk,tol=1.e-13): # pragma: no cover
-    from numpy import dot,zeros,all,sum,abs
+    from numpy import dot, zeros, all, abs
+    import numpy
     coneq = zeros((40000))
     A=rk.A
     b=rk.b
     c=rk.c
-    coneq[0]=sum(b)-1.
+    coneq[0] = sum(b) - 1.0
     if any(abs(coneq)>tol):
         return 0
     # order 2 conditions:
@@ -20343,5 +20346,5 @@ def order(rk,tol=1.e-13): # pragma: no cover
     if any(abs(coneq)>tol):
         return 12
     else:
-        print 'This routine only goes up to order 13.  Use oc_butcher_high_order for higher orders.'
+        print('This routine only goes up to order 13.  Use oc_butcher_high_order for higher orders.')
         return 13

--- a/nodepy/ode_solver.py
+++ b/nodepy/ode_solver.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+
 import numbers
 
 #=====================================================
@@ -56,7 +59,7 @@ class ODESolver(object):
             the solution is integrated to T[-1] and the solution is returned
             for the times specified in T.
 
-            TODO: 
+            TODO:
 
                 * Implement an option to not keep all output (for efficiency).
                 * Option to keep error estimate history
@@ -90,8 +93,8 @@ class ODESolver(object):
             dt_standard = dt + 0
             for istep in range(max_steps):
 
-                if t_current+dt >= next_out:
-                    print t_current, dt, next_out
+                if (t_current + dt) >= next_out:
+                    #print(t_current, dt, next_out) # tests don't expect this
                     dt = next_out - t_current
                     out_now = True
 
@@ -119,7 +122,7 @@ class ODESolver(object):
 
             for istep in range(max_steps):
                 # Hit next output time exactly:
-                if t_current+dt >= next_out: 
+                if t_current+dt >= next_out:
                     dt = next_out - t_current
                     out_now = True
 
@@ -139,30 +142,31 @@ class ODESolver(object):
                     errestold = errest #Should this happen if step is rejected?
                     dthist.append(dt)
                     errest_hist.append(errest)
-                else: 
+                else:
                     rejected_steps+=1
 
                 out_now = False
 
                 if controllertype=='P':
                   #Compute new dt using P-controller
-                  facopt = (errtol/(errest+1.e-6*errtol))**alpha 
+                  facopt = (errtol/(errest+1.e-6*errtol))**alpha
 
                 elif controllertype=='PI':
                   #Compute new dt using PI-controller
                   facopt = ((errtol/errest)**alpha
                             *(errestold/errtol)**beta)
-                else: print 'Unrecognized time step controller type'
+                else:
+                    print('Unrecognized time step controller type')
 
                 # Set new step size
                 dt = dt * min(facmax,max(facmin,kappa*facopt))
 
             if istep==max_steps-1:
-                print 'Maximum number of steps reached; giving up.'
+                print('Maximum number of steps reached; giving up.')
 
-        if diagnostics==False: 
+        if diagnostics==False:
             return t, u
-        else: 
+        else:
             if errtol is None:
                 return t,u,rejected_steps,dthist
             else:

--- a/nodepy/rooted_trees.py
+++ b/nodepy/rooted_trees.py
@@ -1,7 +1,9 @@
+from __future__ import print_function
+
 import numpy as np
 from sympy import factorial, sympify, Rational
 #from sage.combinat.combinat import permutations
-from utils import permutations
+from nodepy.utils import permutations
 
 #=====================================================
 class RootedTree(str):
@@ -9,14 +11,14 @@ class RootedTree(str):
     r"""
         A rooted tree is a directed acyclic graph with one node, which
         has no incoming edges, designated as the root.
-        Rooted trees are useful for analyzing the order conditions of 
-        multistage numerical ODE solvers, such as Runge-Kutta methods 
+        Rooted trees are useful for analyzing the order conditions of
+        multistage numerical ODE solvers, such as Runge-Kutta methods
         and other general linear methods.
 
         The trees are represented as strings, using one of the notations
         introduced by Butcher (the third column of Table 300(I) of
-        Butcher's text).  The character 'T' is used in place of $\\tau$ 
-        to represent a vertex, and braces '{ }' are used instead of brackets 
+        Butcher's text).  The character 'T' is used in place of $\\tau$
+        to represent a vertex, and braces '{ }' are used instead of brackets
         '[ ]' to indicate that everything inside the braces
         is joined to a single parent node.  Thus the first four trees are:
 
@@ -26,24 +28,24 @@ class RootedTree(str):
         returns a list of all trees of a given order::
 
             >>> from nodepy import *
-            >>> for p in range(4): print rt.list_trees(p)
+            >>> for p in range(4): print(rt.list_trees(p))
             ['']
             ['T']
             ['{T}']
             ['{{T}}', '{T^2}']
-            
+
         Note that the tree of order 0 is indicated by an empty string.
-        
+
         If the tree contains an edge from vertex A to vertex B, vertex
         B is said to be a child of vertex A.
-        A vertex with no children is referred to as a leaf.  
+        A vertex with no children is referred to as a leaf.
 
         .. warning::
 
-            One important convention is assumed in the code; namely, that at each 
-            level, leaves are listed first (before any other subtrees), 
+            One important convention is assumed in the code; namely, that at each
+            level, leaves are listed first (before any other subtrees),
             and if there are $n$ leaves, we write 'T^n'.
-        
+
         .. note::
 
             Currently, powers cannot be used for subtrees; thus
@@ -52,7 +54,7 @@ class RootedTree(str):
 
             is valid, while
 
-            '{{T}^2}' 
+            '{{T}^2}'
 
             is not.  This restriction may be lifted in the future.
 
@@ -79,7 +81,7 @@ class RootedTree(str):
             >>> rk.elementary_weight_str(tree)
             'dot(b,dot(A,c)*dot(A,c*dot(A,c))*c**2)'
 
-        **References**:  
+        **References**:
             #. [butcher2003]_
             #. [hairer1993]_
     """
@@ -98,7 +100,7 @@ class RootedTree(str):
 
     def order(self):
         """
-        The order of a rooted tree, denoted $r(t)$, is the number of 
+        The order of a rooted tree, denoted $r(t)$, is the number of
         vertices in the tree.
 
         **Examples**::
@@ -108,7 +110,7 @@ class RootedTree(str):
             >>> tree.order()
             7
         """
-        from strmanip import getint
+        from nodepy.strmanip import getint
         if self=='T': return 1
         if self=='':  return 0
         r=self.count('{')
@@ -132,7 +134,7 @@ class RootedTree(str):
             >>> tree.density()
             56
 
-        **Reference**: 
+        **Reference**:
 
             - [butcher2003]_ p. 127, eq. 301(c)
         """
@@ -143,7 +145,7 @@ class RootedTree(str):
         return gamma
 
     def symmetry(self):
-        r""" 
+        r"""
         The symmetry $\\sigma(t)$ of a rooted tree is...
 
         **Examples**::
@@ -153,11 +155,11 @@ class RootedTree(str):
             >>> tree.symmetry()
             2
 
-        **Reference**: 
+        **Reference**:
 
             - [butcher2003]_ p. 127, eq. 301(b)
         """
-        from strmanip import getint
+        from nodepy.strmanip import getint
         if self=='T': return 1
         sigma=1
         if self[1]=='T':
@@ -173,17 +175,17 @@ class RootedTree(str):
 
 
     def Dmap(self):
-        """ 
+        """
         Butcher's function $D(t)$.  Represents differentiation.
         Defined by $D(t)$=0 except for D('T')=1.
 
-        **Reference**: 
+        **Reference**:
             #. [butcher1997]_
         """
         return self=='T'
 
     def lamda(self,alpha,extraargs=[]):
-        r""" 
+        r"""
             Computes Butcher's functional lambda on a given tree
             for the function alpha.  This is used to compute the
             product of two functions on trees.
@@ -191,15 +193,15 @@ class RootedTree(str):
             *INPUT*:
 
                 * alpha -- a function on rooted trees
-                * extraargs -- a list containing any additional arguments 
+                * extraargs -- a list containing any additional arguments
                   that must be passed to alpha
 
             *OUTPUT*:
                 * tprod -- a list of trees [t1, t2, ...]
                 * fprod -- a list of numbers [a1, a2, ...]
 
-            The meaning of the output is that 
-            $\\lambda(\\alpha,t)(\\beta)=a1*\\beta(t1)+a2*\\beta(t2)+...$ 
+            The meaning of the output is that
+            $\\lambda(\\alpha,t)(\\beta)=a1*\\beta(t1)+a2*\\beta(t2)+...$
 
             **Examples**::
 
@@ -208,7 +210,7 @@ class RootedTree(str):
                 >>> tree.lamda(rt.Emap)
                 (['T', '{T}', '{{T}}', '{T}', '{T^2}', '{T{T}}'], [1/2, 1, 1, 1/2, 1, 1])
 
-            **Reference**: 
+            **Reference**:
                 [butcher2003]_ pp. 275-276
         """
         if self=='': return [RootedTree('')],[0]
@@ -263,12 +265,12 @@ class RootedTree(str):
         return tprod,fprod
 
     def _factor(self):
-        """ 
+        """
             Returns two rooted trees, t and u, such that self=t*u.
 
-            **Input**: 
+            **Input**:
                 - self -- any rooted tree
-            **Output**: 
+            **Output**:
                 - t,u -- a pair of rooted trees whose product t*u is equal to self.
 
             **Examples**::
@@ -304,15 +306,15 @@ class RootedTree(str):
         return t,u
 
     def Gprod(self,alpha,beta,alphaargs=[],betaargs=[]):
-        r""" 
+        r"""
             Returns the product of two functions on a given tree.
 
             INPUT:
                 alpha, beta -- two functions on rooted trees
                                that return symbolic or numeric values
-                alphaargs   -- a string containing any additional arguments 
+                alphaargs   -- a string containing any additional arguments
                                 that must be passed to function alpha
-                betaargs    -- a string containing any additional arguments 
+                betaargs    -- a string containing any additional arguments
                                 that must be passed to function beta
 
             OUTPUT:
@@ -339,7 +341,7 @@ class RootedTree(str):
                 >>> tree.Gprod(rt.Emap,Dmap)
                 1/2
 
-            **Reference**: [butcher2003]_ p. 276, Thm. 386A 
+            **Reference**: [butcher2003]_ p. 276, Thm. 386A
         """
         trees,factors=self.lamda(alpha,*alphaargs)
         s=0
@@ -349,7 +351,7 @@ class RootedTree(str):
         return s
 
     def Gprod_str(self,alpha,beta,alphaargs=[],betaargs=[]):
-        """ 
+        """
             Alternate version of Gprod, but operates on strings.
             Hopefully can be eliminated later in favor of symbolic
             manipulation.
@@ -384,7 +386,7 @@ class RootedTree(str):
             *OUTPUT*: None.
 
             The plot is created recursively by
-            plotting the root, parsing the subtrees, plotting the 
+            plotting the root, parsing the subtrees, plotting the
             subtrees' roots, and calling _plot_subtree on each child
         """
         import matplotlib.pyplot as pl
@@ -409,7 +411,7 @@ class RootedTree(str):
             Recursively plots subtrees.  Should only be called from plot().
 
             INPUT:
-                xroot, yroot -- coordinates at which root of this subtree 
+                xroot, yroot -- coordinates at which root of this subtree
                                 is plotted
                 xwidth -- width in which this subtree must fit, in order
                             to avoid possibly overlapping with others
@@ -429,7 +431,7 @@ class RootedTree(str):
 
 
     def _parse_subtrees(self):
-        """ 
+        """
             Returns the number of leaves and a list of the subtrees,
             for a given rooted tree.
 
@@ -442,12 +444,12 @@ class RootedTree(str):
             returning possibly many copies of 'T', the leaves are just
             returned as a number.
         """
-        from strmanip import get_substring, open_to_close, getint
+        from nodepy.strmanip import get_substring, open_to_close, getint
         if str(self)=='T' or str(self)=='': return 0,[]
         pos=0
         #Count leaves at current level
-        if self[1]=='T':    
-            if self[2]=='^': 
+        if self[1]=='T':
+            if self[2]=='^':
                 nleaves=getint(self[3:])
             else: nleaves=1
         else: nleaves=0
@@ -462,13 +464,13 @@ class RootedTree(str):
         return nleaves,subtrees
 
     def list_equivalent_trees(self):
-        """ 
+        """
             Returns a list of all strings (subject to our assumptions)
-            equivalent to a given tree 
+            equivalent to a given tree
 
-            INPUT: 
+            INPUT:
                 self     -- any rooted tree
-            OUTPUT:  
+            OUTPUT:
                 treelist -- a list of all the 'legal' tree strings
                             that produce the same tree.
 
@@ -494,11 +496,11 @@ class RootedTree(str):
         else: return False
 
     def __mul__(self,tree2):
-        """ 
-            Returns Butcher's product: t*u is the tree obtained by
-            attaching the root of u as a child to the root of t. 
         """
-        from strmanip import getint
+            Returns Butcher's product: t*u is the tree obtained by
+            attaching the root of u as a child to the root of t.
+        """
+        from nodepy.strmanip import getint
         if self=='T': return RootedTree('{'+tree2+'}')
         if tree2=='T':  # We're just adding a leaf to self
             nleaves,subtrees=self._parse_subtrees()
@@ -542,26 +544,26 @@ def plot_all_trees(p,title='str'):
 #=====================================================
 def list_trees(p,ind='all'):
 #=====================================================
-    """ 
+    """
     Returns rooted trees of order p.
 
-    INPUT: 
-    
+    INPUT:
+
         - p   -- order of trees desired
         - ind -- if given, returns a single tree corresponding to this index.
                 Not very useful since the ordering isn't obvious.
-                
+
     OUTPUT: list of all trees of order p (or just one, if ind is provided).
-    
+
     Generates the rooted trees using Albrecht's 'Recursion 3'.
 
     **Examples**:
 
     Produce column of Butcher's Table 302(I)::
 
-        >>> for i in range(1,11): 
+        >>> for i in range(1,11):
         ...     forest=list_trees(i)
-        ...     print len(forest)
+        ...     print(len(forest))
         1
         1
         2
@@ -575,7 +577,7 @@ def list_trees(p,ind='all'):
 
     .. warning::
 
-        This code is complete only up to order 10.  We need to extend it 
+        This code is complete only up to order 10.  We need to extend it
         by adding more subloops for p>10.
 
     TODO: Implement Butcher's formula (Theorem 302B) for the number
@@ -646,10 +648,10 @@ def list_trees(p,ind='all'):
     for i in range(1,p):
         ps=_powerString("T",i,powchar="^")
         W[i].append(RootedTree("{"+ps+"}"))
-  
+
     if ind=='all': return W[p-1]
     else: return W[p-1][ind]
-    
+
 
 def _powerString(s,npow,powchar="**",trailchar=''):
     r"""Raise string s to power npow with additional formatting."""
@@ -698,7 +700,7 @@ def Dprod_str(tree,alpha):
     return result
 
 def Dmap(tree):
-    """ 
+    """
     Butcher's function D(t).  Represents differentiation.
     Defined by D(t)=0 except for D('T')=1.
     """
@@ -716,7 +718,7 @@ def Gprod_str(tree,alpha,beta,alphaargs='',betaargs=[]):
     return tree.Gprod_str(alpha,beta,alphaargs,betaargs)
 
 def Emap(tree,a=1):
-    """ 
+    """
     Butcher's function E^a(t).
     Gives the B-series for the exact solution advanced 'a' steps
     in time.
@@ -730,7 +732,7 @@ def Emap(tree,a=1):
         >>> rt.Emap(tree,a=2)
         16/7
 
-    **Reference**: 
+    **Reference**:
 
         [butcher1997]_
     """
@@ -743,7 +745,7 @@ def Emap_str(tree,a=1):
 #=====================================================
 def recursiveVectors(p,ind='all'):
 #=====================================================
-  """ 
+  """
     Generate recursive vectors using Albrecht's 'recursion 1'.
     These are essentially the order conditions for Runge-Kutta
     methods, excluding those that correspond to bushy trees.
@@ -759,7 +761,7 @@ def recursiveVectors(p,ind='all'):
 
     .. warning::
 
-        This code is complete only up to order 12.  We need to extend it 
+        This code is complete only up to order 12.  We need to extend it
         by adding more subloops for p>12.
 
     **Example**
@@ -768,10 +770,10 @@ def recursiveVectors(p,ind='all'):
 
         >>> from nodepy import rt
         >>> v = rt.recursiveVectors(12)
-        >>> print len(v)
+        >>> print(len(v))
         4769
   """
-  if p>12: print 'recursiveVectors is not complete for orders p>12.'
+  if p>12: print('recursiveVectors is not complete for orders p > 12.')
   W=[[],[]]
   R=[[],[]]
   R.append(["tau[2]"])

--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -20,10 +20,10 @@
 * Load a dictionary with many methods::
 
     >>> RK=loadRKM()
-    >>> RK.keys()
-    ['BE', 'SSP75', 'SDIRK34', 'Fehlberg45', 'FE', 'Merson43', 'SSP33', 'MTE22', 'PD8', 'SSP95', 'SDIRK23', 'RK44', 'SSP22star', 'RadauIIA3', 'RadauIIA2', 'BS5', 'LobattoIIIA2', 'Lambert65', 'Heun33', 'SSP22', 'DP5', 'GL3', 'NSSP33', 'NSSP32', 'SSP85', 'CMR6', 'BuRK65', 'SSP104', 'LobattoIIIA3', 'SDIRK54', 'GL2', 'LobattoIIIC4', 'LobattoIIIC3', 'LobattoIIIC2', 'Mid22']
+    >>> sorted(RK.keys())
+    ['BE', 'BS5', 'BuRK65', 'CMR6', 'DP5', 'FE', 'Fehlberg45', 'GL2', 'GL3', 'Heun33', 'Lambert65', 'LobattoIIIA2', 'LobattoIIIA3', 'LobattoIIIC2', 'LobattoIIIC3', 'LobattoIIIC4', 'MTE22', 'Merson43', 'Mid22', 'NSSP32', 'NSSP33', 'PD8', 'RK44', 'RadauIIA2', 'RadauIIA3', 'SDIRK23', 'SDIRK34', 'SDIRK54', 'SSP104', 'SSP22', 'SSP22star', 'SSP33', 'SSP53', 'SSP54', 'SSP63', 'SSP75', 'SSP85', 'SSP95']
 
-    >>> print RK['Mid22']
+    >>> print(RK['Mid22'])
     Midpoint Runge-Kutta
     <BLANKLINE>
      0   |
@@ -46,30 +46,33 @@
          | 1/4            3/4  |                1/4
 
 
-**References**:  
+**References**:
     #. [butcher2003]_
     #. [hairer1993]_
 """
+from __future__ import print_function
 from __future__ import division
-from general_linear_method import GeneralLinearMethod
+
 import numpy as np
-import snp
 import sympy
+
+import nodepy.snp as snp
+from nodepy.general_linear_method import GeneralLinearMethod
 
 
 #=====================================================
 class RungeKuttaMethod(GeneralLinearMethod):
 #=====================================================
-    r""" 
+    r"""
         General class for implicit and explicit Runge-Kutta Methods.
         The method is defined by its Butcher array (`A,b,c`).
         It is assumed everywhere that  `c_i=\sum_j A_{ij}`.
-        
+
         A Runge-Kutta Method is initialized by providing either:
-            #. Butcher arrays `A` and `b` with valid and consistent 
+            #. Butcher arrays `A` and `b` with valid and consistent
                dimensions; or
             #. Shu-Osher arrays `\alpha` and `\beta` with valid and
-               consistent dimensions 
+               consistent dimensions
 
         but not both.
 
@@ -152,9 +155,9 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
         if not isinstance(self,ExplicitRungeKuttaMethod):
             if not np.triu(self.A).any():
-                print """Warning: this method appears to be explicit, but is
+                print("""Warning: this method appears to be explicit, but is
                        being initialized as a RungeKuttaMethod rather than
-                       as an ExplicitRungeKuttaMethod."""
+                       as an ExplicitRungeKuttaMethod.""")
 
         if order is not None:
             self._p = order
@@ -180,7 +183,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         """
         import copy
         numself = copy.deepcopy(self)
-        if self.A.dtype==object:
+        if self.A.dtype == object or self.b.dtype == object:
             numself.A=np.array(self.A,dtype=np.float64)
             numself.b=np.array(self.b,dtype=np.float64)
             numself.c=np.array(self.c,dtype=np.float64)
@@ -190,12 +193,12 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
     def latex(self):
         r"""A laTeX representation of the Butcher arrays.
-        
+
             **Example**::
 
             >>> from nodepy import rk
             >>> merson = rk.loadRKM('Merson43')
-            >>> print merson.latex()
+            >>> print(merson.latex())
             \begin{align}
             \begin{array}{c|ccccc}
              &  &  &  &  & \\
@@ -209,7 +212,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
             \end{array}
             \end{align}
         """
-        from snp import printable
+        from nodepy.snp import printable
         sep = ' & '
         s= r'\begin{align}' + '\n'
         s+=r'\begin{array}{c|'
@@ -247,7 +250,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         if (self.alpha is None or self.beta is None):
             raise Exception('Shu-Osher arrays not defined for this method.')
 
-        from utils import array2strings
+        from nodepy.utils import array2strings
 
         c = array2strings(self.c)
         alpha = array2strings(self.alpha)
@@ -270,7 +273,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         s+=' |'
         for j in range(len(self)):
             s+=beta[-1,j].ljust(colmax+1)
-        print s.rstrip()
+        print(s.rstrip())
 
 
     def __str__(self):
@@ -282,7 +285,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         ______
           | b
         """
-        from utils import array2strings
+        from nodepy.utils import array2strings
 
         c = array2strings(self.c,printzeros=True)
         A = array2strings(self.A)
@@ -300,7 +303,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         for j in range(len(self)):
             s+=b[j].ljust(colmax+1)
         return s.rstrip()
-     
+
     def __eq__(self,rkm):
         """
             Methods considered equal if their Butcher arrays are
@@ -318,7 +321,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
             Check that the two are actually equal::
 
-                >>> print reduced == merson
+                >>> print(reduced == merson)
                 True
         """
         K1=np.vstack([self.A,self.b])
@@ -332,7 +335,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         """
             The length of the method is the number of stages.
         """
-        return np.size(self.A,0) 
+        return np.size(self.A,0)
 
     def __mul__(self,RK2):
         """ Multiplication is interpreted as composition:
@@ -384,9 +387,9 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 for i in range(len(self)):
                     if i not in Nset and abs(A[i,j])>tol: #Stage j matters
                         remove_j=True
-                        continue       
+                        continue
                     if remove_j: continue
-                if remove_j: 
+                if remove_j:
                     Nset.remove(j)
                     continue
             if Nset==Nsetold: return Nset
@@ -402,7 +405,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
             does not influence the output.
 
             **Examples**::
-            
+
                 Construct a reducible method:
                 >>> from nodepy import rk
                 >>> A=np.array([[0,0],[1,0]])
@@ -414,9 +417,9 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 [1]
 
                 Reduce it:
-                >>> print rkm.dj_reduce()
+                >>> print(rkm.dj_reduce())
                 Runge-Kutta Method
-                <BLANKLINE>                
+                <BLANKLINE>
                  0 |
                 ___|___
                    | 1
@@ -429,14 +432,14 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
 
     def _hs_reducible_stages(self,tol=1.e-13):
-        """ 
+        """
             Determine whether the method is HS-reducible.
             A Runge-Kutta method is HS-reducible if two
             rows of A are equal.
 
             If the method is HS-reducible, returns True and a
             pair of equal stages.  If not, returns False and
-            the minimum pairwise difference (in the maximum norm) 
+            the minimum pairwise difference (in the maximum norm)
             between rows of A.
 
             **Examples**::
@@ -505,7 +508,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         corresponding to a given tree.
 
            **Examples**::
-            
+
                 Construct an RK method and some rooted trees:
                 >>> from nodepy import rk, rt
                 >>> rk4 = rk.loadRKM('RK44')
@@ -527,17 +530,17 @@ class RungeKuttaMethod(GeneralLinearMethod):
         A,b,c = self.A,self.b,self.c
 
         if A.dtype == object:
-            exec('coeff=simplify('+code+'-Rational(1,'+str(tree.density())+'))')
+            exec('coeff = simplify({} - Rational(1, {}))'.format(code, tree.density()))
         else:
-            exec('coeff=('+code+'-1./'+str(tree.density())+')')
-        return coeff/tree.symmetry()
+            exec("coeff = ({} - 1.0 / {})".format(code, tree.density()))
+        return locals()["coeff"] / tree.symmetry()
 
     def error_coeffs(self,p):
         r"""
         Returns the coefficients in the Runge-Kutta method's error expansion
         multiplying all elementary differentials of the given order.
         """
-        import rooted_trees as rt
+        import nodepy.rooted_trees as rt
         forest=rt.list_trees(p)
         err_coeffs=[]
         for tree in forest:
@@ -561,7 +564,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> rk4.error_metrics()
                 (sqrt(1745)/2880, 1/120, sqrt(8531)/5760, 1/144, 1)
-                
+
             Reference: [kennedy2000]_
         """
         q=self.order()
@@ -580,7 +583,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
     def principal_error_norm(self,tol=1.e-13,mode='float'):
         r"""The 2-norm of the vector of leading order error coefficients."""
-        import rooted_trees as rt
+        import nodepy.rooted_trees as rt
         forest=rt.list_trees(self.p+1)
         errs=[]
 
@@ -624,13 +627,13 @@ class RungeKuttaMethod(GeneralLinearMethod):
         """
         if mode=='float':
             if not extremely_high_order:
-                import oc_butcher
+                import nodepy.oc_butcher as oc_butcher
                 p = oc_butcher.order(self.__num__(),tol)
             else:
-                import oc_butcher_high_order
+                import nodepy.oc_butcher_high_order as oc_butcher_high_order
                 p = oc_butcher_high_order.order(self.__num__(),tol)
             if p==0:
-                print 'Apparent order is 0; this may be due to roundoff.  Try order(mode="exact") or increase tol.'
+                print('Apparent order is 0; this may be due to round-off.  Try order(mode="exact") or increase tol.')
         elif mode=='exact':
             from sympy import simplify
             p=0
@@ -661,7 +664,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         return z
 
     def effective_order(self,tol=1.e-14):
-        """ 
+        """
             Returns the effective order of a Runge-Kutta method.
             This may be higher than the classical order.
 
@@ -710,8 +713,8 @@ class RungeKuttaMethod(GeneralLinearMethod):
         return z
 
     def stage_order(self,tol=1.e-14):
-        r""" 
-            The stage order of a Runge-Kutta method is the minimum, 
+        r"""
+            The stage order of a Runge-Kutta method is the minimum,
             over all stages, of the
             order of accuracy of that stage.  It can be shown to be
             equal to the largest integer k such that the simplifying
@@ -762,7 +765,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         z = sympy.var('z')
         s = len(self)
         I = sympy.eye(s)
-        
+
         v = 1 - self.alpha.sum(1)
         vstar = sympy.Matrix(v[:-1])
         v_mp1 = sympy.Rational(v[-1])
@@ -776,7 +779,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
 
     def stability_function(self,stage=None,mode='exact',formula='lts',use_butcher=False):
-        r""" 
+        r"""
             The stability function of a Runge-Kutta method is
             `\\phi(z)=p(z)/q(z)`, where
 
@@ -790,7 +793,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
             where `e` is a column vector with all entries equal to one.
 
-            This function constructs the numerator and denominator of the 
+            This function constructs the numerator and denominator of the
             stability function of a Runge-Kutta method.
 
             For methods with rational coefficients, mode='exact' computes
@@ -824,7 +827,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 >>> from nodepy import rk
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> p,q = rk4.stability_function()
-                >>> print p
+                >>> print(p)
                          4          3       2
                 0.04167 x + 0.1667 x + 0.5 x + 1 x + 1
 
@@ -889,7 +892,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 p = np.poly1d(p.coeffs[(d_num-d_true):])
 
         return p,q
-        
+
 
     def plot_stability_function(self,bounds=[-20,1]):
         r"""Plot the value of the stability function along the negative real axis.
@@ -913,7 +916,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
     def plot_stability_region(self,N=200,color='r',filled=True,bounds=None,
                               plotroots=False,alpha=1.,scalefac=1.,
                               to_file=False, longtitle=True,fignum=None):
-        r""" 
+        r"""
             The region of absolute stability
             of a Runge-Kutta method, is the set
 
@@ -933,7 +936,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 >>> rk4.plot_stability_region() #doctest: +ELLIPSIS
                 <matplotlib.figure.Figure object at 0x...>
         """
-        import stability_function 
+        import nodepy.stability_function as stability_function
         import matplotlib.pyplot as plt
 
         p,q=self.__num__().stability_function(mode='float')
@@ -955,7 +958,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
     def plot_order_star(self,N=200,bounds=[-5,5,-5,5],plotroots=False,
                         color=('w','b'),filled=True,fignum=None):
         r""" The order star of a Runge-Kutta method is the set
-            
+
             $$ \\{ z \\in C : | \\phi(z)/\\exp(z) | \\le 1 \\} $$
 
             where `\phi(z)` is the stability function of the method.
@@ -972,7 +975,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 >>> rk4.plot_order_star() # doctest: +ELLIPSIS
                 <matplotlib.figure.Figure object at 0x...>
         """
-        import stability_function
+        import nodepy.stability_function as stability_function
         import matplotlib.pyplot as plt
 
         p,q=self.__num__().stability_function(mode='float')
@@ -980,12 +983,12 @@ class RungeKuttaMethod(GeneralLinearMethod):
         fig = stability_function.plot_order_star(p,q,N,bounds,plotroots,color,filled,fignum)
         plt.title('Order star for '+self.name)
         return fig
-        
+
     #============================================================
     # Nonlinear Stability
     #============================================================
     def circle_contractivity_radius(self,acc=1.e-13,rmax=1000):
-        r""" 
+        r"""
             Returns the radius of circle contractivity
             of a Runge-Kutta method.
 
@@ -997,7 +1000,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 1.000...
 
         """
-        from utils import bisect
+        from nodepy.utils import bisect
 
         tol=1.e-14
         r=bisect(0,rmax,acc,tol,self.__num__()._is_circle_contractive)
@@ -1005,13 +1008,13 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
     def absolute_monotonicity_radius(self,acc=1.e-10,rmax=200,
                     tol=3.e-16):
-        r""" 
+        r"""
             Returns the radius of absolute monotonicity
             (also referred to as the radius of contractivity or
-            the strong stability preserving coefficient 
+            the strong stability preserving coefficient
             of a Runge-Kutta method.
         """
-        from utils import bisect
+        from nodepy.utils import bisect
 
         r=bisect(0,rmax,acc,tol,self._is_absolutely_monotonic)
         if r>=rmax-acc: return np.inf
@@ -1035,7 +1038,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
         phi = lambda z: p(z)/q(z)
         #Get the negative real zeroes of the derivative of p/q:
         phip=p.deriv()*q-q.deriv()*p
-        zeroes=[z for z in phip.r if np.isreal(z) and z<0]      
+        zeroes=[z for z in phip.r if np.isreal(z) and z<0]
         #Find the extremum of phi on (-inf,0):
         xmax=-10000
         if phip(0)<0: return 0
@@ -1045,15 +1048,15 @@ class RungeKuttaMethod(GeneralLinearMethod):
                     xmax=zeroes[i]
             zmax=max(abs(phi(zeroes)))
             rlo=max(zeroes)
-            if p.order==q.order: 
+            if p.order==q.order:
                 zmax=max(zmax, abs(p[len(p)]/q[len(q)]))
         else:
             if p.order<q.order: return -np.inf
-            if p.order==q.order: 
+            if p.order==q.order:
                 zmax=abs(p[len(p)]/q[len(q)])
                 if p[len(p)]/q[len(q)]>=-tol: return -np.inf
                 rlo=-10000
-        s=p-zmax*q 
+        s=p-zmax*q
         zeroes2=[z for z in s.r if np.isreal(z) and z<0 and z>=xmax]
         if len(zeroes2)>0:
             r=max(zeroes2)
@@ -1064,7 +1067,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
     def _is_circle_contractive(self,r,tol):
         r""" Returns 1 if the Runge-Kutta method has radius of circle
             contractivity at least `r`.
-            
+
             **References**:
                 #. Dekker and Verwer
         """
@@ -1118,13 +1121,13 @@ class RungeKuttaMethod(GeneralLinearMethod):
             evident (i.e., in which `\\alpha_{ij},\\beta_{ij} \\ge 0` and
             `\\alpha_{ij}/\\beta_{ij}=c` for every `\\beta_{ij}\\ne 0`).
 
-            **Input**: 
+            **Input**:
                 - A RungeKuttaMethod
-            **Output**: 
+            **Output**:
                 - alpha, beta -- Shu-Osher arrays
 
             The 'optimal' Shu-Osher arrays are given by
-            
+
             $$\\alpha= K(I+cA)^{-1}$$
             $$\\beta = c \\alpha$$
 
@@ -1142,7 +1145,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
                        [0.666666666666667, 0, 0],
                        [4.00177668780088e-11, 0.750000000000000, 0]], dtype=object))
 
-            **References**: 
+            **References**:
                 #. [higueras2005]_
 
         """
@@ -1220,7 +1223,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
     def ssplit(self,r,P_signs=None,delta=None):
         """Sympy exact version of split()
-        
+
         If P_signs is passed, use that as the sign pattern of the P matrix.
         This is useful if r is symbolic (since then in general the signs of
         elemnts of P are unknown).
@@ -1281,9 +1284,9 @@ class RungeKuttaMethod(GeneralLinearMethod):
 
     def is_splittable(self,r,tol=1.e-15):
         d,alpha,alphatilde=self.resplit(r,tol=tol)
-        if alpha.min()>=-tol and d.min()>=-tol and alphatilde.min()>=-tol: 
+        if alpha.min()>=-tol and d.min()>=-tol and alphatilde.min()>=-tol:
             return True
-        else: 
+        else:
             return False
 
     def optimal_perturbed_splitting(self,acc=1.e-12,rmax=50.01,tol=1.e-13,algorithm='split'):
@@ -1300,10 +1303,10 @@ class RungeKuttaMethod(GeneralLinearMethod):
                 >>> from nodepy import rk
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> r, d, alpha, alphatilde = rk4.optimal_perturbed_splitting(algorithm='split')
-                >>> print r # doctest: +ELLIPSIS
+                >>> print(r) # doctest: +ELLIPSIS
                 0.68501606...
         """
-        from utils import bisect
+        from nodepy.utils import bisect
         try:
             import cvxpy as cvx
         except:
@@ -1322,10 +1325,10 @@ class RungeKuttaMethod(GeneralLinearMethod):
     #============================================================
     def propagation_matrix(self,L,dt):
         """
-            Returns the solution propagation matrix for the linear 
-            autonomous system with RHS equal to the matrix L, i.e. 
+            Returns the solution propagation matrix for the linear
+            autonomous system with RHS equal to the matrix L, i.e.
             it returns the matrix G such that when the Runge-Kutta
-            method is applied to the system 
+            method is applied to the system
             `u'(t)=Lu`
             with stepsize dt, the numerical solution is given by
             `u^{n+1} = G u^n`.
@@ -1339,7 +1342,7 @@ class RungeKuttaMethod(GeneralLinearMethod):
             `G = 1 + b^T L (I-A L)^{-1} e`
 
             where `A` and `b` are the Butcher arrays and `e` is the vector
-            of ones.  If `L` is a matrix, all quantities above are 
+            of ones.  If `L` is a matrix, all quantities above are
             replaced by their Kronecker product with the identity
             matrix of size `m`, where `m` is the number of stages of
             the Runge-Kutta method.
@@ -1412,8 +1415,8 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
         if self.alpha is None:
             use_butcher = True
 
-	m=len(self)
-        u_old = u		# Initial value
+        m=len(self)
+        u_old = u       # Initial value
         size = np.size(u_old)
         y = [np.zeros((size)) for i in range(m+1)]
         fy = [np.zeros((size)) for i in range(m)]
@@ -1430,8 +1433,8 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                     y[i] += self.A[i,j]*dt*fy[j]
                     if x is not None: fy[i][:] = f(t+self.c[i]*dt,y[i],x)
                     else: fy[i][:] = f(t+self.c[i]*dt,y[i])
-            u_new=u_old+dt*sum([self.b[j]*fy[j] for j in range(m)])	
- 
+            u_new=u_old+dt*sum([self.b[j]*fy[j] for j in range(m)])
+
         else:             # Use Shu-Osher coefficients
             v = 1 - self.alpha.sum(1)
             for i in range(1,m+1):
@@ -1442,7 +1445,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                     if x is not None: fy[i][:] = f(t+self.c[i]*dt,y[i],x)
                     else: fy[i][:] = f(t+self.c[i]*dt,y[i])
             u_new = y[m]
-    
+
         return u_new
 
 
@@ -1459,7 +1462,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 >>> rk4.imaginary_stability_interval() # doctest: +ELLIPSIS
                 2.8284271247461...
         """
-        import stability_function
+        import nodepy.stability_function as stability_function
         p,q=self.stability_function(mode=mode)
         return stability_function.imaginary_stability_interval(p,q,eps=eps)
 
@@ -1473,23 +1476,23 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 >>> from nodepy import rk
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> I = rk4.real_stability_interval()
-                >>> print "%.10f" % I
+                >>> print("{:.10f}".format(I))
                 2.7852935634
         """
-        import stability_function
+        import nodepy.stability_function as stability_function
         p,q=self.stability_function(mode=mode)
         return stability_function.real_stability_interval(p,q,eps=eps)
 
 
     def linear_absolute_monotonicity_radius(self,acc=1.e-10,rmax=50,
                                             tol=3.e-16):
-        """ 
+        """
             Returns the radius of absolute monotonicity
             of the stability function of a Runge-Kutta method.
 
             TODO: implement this functionality for implicit methods.
         """
-        from utils import bisect
+        from nodepy.utils import bisect
         p,q=self.stability_function()
         if q.order!=0 or q[0]!=1:
             raise NotImplementedError(
@@ -1520,7 +1523,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 7
                 >>> ex4.num_seq_dep_stages()
                 4
-                
+
                 So are deferred correction methods:
                 >>> dc4 = rk.DC(4)
                 >>> len(dc4)
@@ -1545,8 +1548,8 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
         return n
 
     def internal_stability_polynomials(self,stage=None,mode='exact',formula='lts',use_butcher=False):
-        r""" 
-            The internal stability polynomials of a Runge-Kutta method 
+        r"""
+            The internal stability polynomials of a Runge-Kutta method
             depend on the implementation and must therefore be constructed
             base on the Shu-Osher form used for the implementation.
             By default the Shu-Osher coefficients are used.  The
@@ -1562,7 +1565,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
             the current time level. Therefore, the first internal polynomial is
             set to zero.
 
-            For symbolic computation, 
+            For symbolic computation,
             this routine has been significantly modified for efficiency
             relative to particular classes of methods.  Two formulas are
             implemented, one based on SymPy's Matrix.lower_triangular_solve()
@@ -1582,7 +1585,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> theta = rk4.internal_stability_polynomials()
                 >>> for p in theta:
-                ...     print p
+                ...     print(p)
                          3          2
                 0.08333 x + 0.1667 x + 0.3333 x
                         2
@@ -1614,7 +1617,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
 
     def internal_stability_plot(self,bounds=None,N=200,use_butcher=False,formula='lts',levels=[1,100,500,1000,1500,10000]):
         r"""Plot internal stability regions.
-        
+
             Plots the $\epsilon$-internal-stability region contours.
 
             By default the Shu-Osher coefficients are used.  The
@@ -1627,11 +1630,11 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 >>> rk4 = rk.loadRKM('RK44')
                 >>> rk4.internal_stability_plot()
         """
-        import stability_function
+        import nodepy.stability_function as stability_function
         import matplotlib.pyplot as plt
-        from utils import find_plot_bounds
+        from nodepy.utils import find_plot_bounds
         from matplotlib.colors import LogNorm
-        
+
         p,q = self.stability_function(use_butcher=use_butcher,formula=formula)
         # Convert coefficients to floats for speed
         if p.coeffs.dtype=='object':
@@ -1647,9 +1650,9 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
         y=np.linspace(bounds[2],bounds[3],N)
         X=np.tile(x,(N,1))
         Y=np.tile(y[:,np.newaxis],(1,N))
-        Z=X+Y*1j
+        Z=X + Y * 1j
 
-        th_vals = np.zeros((len(theta),N,N))
+        th_vals = np.zeros((len(theta), N, N), dtype=np.complex64)
 
         for j in range(len(theta)):
             thetaj = np.poly1d([float(c) for c in theta[j].coeffs])
@@ -1691,7 +1694,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
                 >>> ssp2.maximum_internal_amplification(use_butcher=True)
                 (2.0370511185806568, 0.0)
         """
-        from utils import find_plot_bounds
+        from nodepy.utils import find_plot_bounds
 
         if (self.alpha is None or self.beta is None): use_butcher = True
 
@@ -1724,7 +1727,7 @@ class ExplicitRungeKuttaMethod(RungeKuttaMethod):
             thetaj = np.poly1d([float(c) for c in thetaj.coeffs])
             maxamp = max(maxamp, np.max(np.abs(thetaj(Z_stable))))
             maxamp_origin = max(maxamp_origin, np.abs(thetaj(0.)))
-            
+
         return maxamp, maxamp_origin
 
 #=====================================================
@@ -1785,7 +1788,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
                         A,b,alpha,beta,name,shortname,description,order=order[0])
         if bhat is None:
             Ahat,bhat=shu_osher_to_butcher(alphahat,betahat)
-        if bhat.shape != self.b.shape: 
+        if bhat.shape != self.b.shape:
             raise Exception("Dimensions of embedded method don't agree with those of principal method")
         self.bhat     = bhat
         self.alphahat = alphahat
@@ -1833,7 +1836,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
           | bhat
         """
         s = super(ExplicitRungeKuttaPair,self).__str__()
-        from utils import array2strings
+        from nodepy.utils import array2strings
 
         c    = array2strings(self.c)
         A    = array2strings(self.A)
@@ -1843,7 +1846,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
         s+= '\n'+' '*(colmax+1)+'|'
         for j in range(len(self)):
             s+=bhat[j].ljust(colmax+1)
-        return s
+        return s.rstrip()
 
 
     def __step__(self,f,t,u,dt,x=None,estimate_error=False,use_butcher=False):
@@ -1867,16 +1870,16 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
         if self.alphahat is None:
             use_butcher = True
 
-	m=len(self)
-        u_old = u[-1]		# Initial value
+        m=len(self)
+        u_old = u       # Initial value
         size = np.size(u_old)
         y = [np.zeros((size)) for i in range(m+1)]
         fy = [np.zeros((size)) for i in range(m)]
 
         # First stage
         y[0][:]=u_old
-        if x is not None: fy[0][:]=f(t[-1],y[0],x)
-        else: fy[0][:]=f(t[-1],y[0])
+        if x is not None: fy[0][:]=f(t,y[0],x)
+        else: fy[0][:]=f(t,y[0])
 
         if use_butcher:                 # Use Butcher coefficients
             for i in range(1,m):        # Compute stage i
@@ -1884,11 +1887,11 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
                 for j in range(i):
                     y[i] += self.A[i,j]*dt*fy[j]
                     if x is not None: fy[i][:] = f(t[-1]+self.c[i]*dt,y[i],x)
-                    else: fy[i][:] = f(t[-1]+self.c[i]*dt,y[i])
-            u_new=u_old+dt*sum([self.b[j]*fy[j] for j in range(m)])	
+                    else: fy[i][:] = f(t+self.c[i]*dt,y[i])
+            u_new=u_old+dt*sum([self.b[j]*fy[j] for j in range(m)])
             if estimate_error:
-                u_hat=u[-1]+dt*sum([self.bhat[j]*fy[j] for j in range(m)])
- 
+                u_hat=u+dt*sum([self.bhat[j]*fy[j] for j in range(m)])
+
         else:             # Use Shu-Osher coefficients
             v = 1 - self.alpha.sum(1)
             for i in range(1,m+1):
@@ -1896,21 +1899,21 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
                 for j in range(i):
                     y[i] += self.alpha[i,j]*y[j] + dt*self.beta[i,j]*fy[j]
                 if i<m:
-                    if x is not None: fy[i][:] = f(t[-1]+self.c[i]*dt,y[i],x)
-                    else: fy[i][:] = f(t[-1]+self.c[i]*dt,y[i])
+                    if x is not None: fy[i][:] = f(t+self.c[i]*dt,y[i],x)
+                    else: fy[i][:] = f(t+self.c[i]*dt,y[i])
             u_new = y[m]
-    
+
             if estimate_error:
                 u_hat = np.zeros(size)
                 #if dt<1e-10:
-                    #print "Warning: very small step size: ", dt, t[-1]
+                    #print("Warning: very small step size: {} {}".format(dt, t[-1]))
                 u_hat = (1-np.sum(self.alphahat[-1,:]))*u_old
                 for j in range(m):
                     u_hat += self.alphahat[-1,j]*y[j] + dt*self.betahat[-1,j]*fy[j]
 
         if estimate_error:
             return u_new, np.max(np.abs(u_new-u_hat))
-        else: 
+        else:
             return u_new
 
     def error_metrics(self,q=None,p=None):
@@ -1928,10 +1931,10 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
         """
         if q is None:
             q=self.order()
-            print 'main method has order '+str(q)
+            print('main method has order {}'.format(q))
         if p is None:
             p=self.embedded_method.order()
-            print 'embedded method has order '+str(p)
+            print('embedded method has order {}'.format(p))
 
         tau_1 = self.error_coeffs(q+1)
         tau_2 = self.error_coeffs(q+2)
@@ -1992,7 +1995,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
                 <matplotlib.figure.Figure object at 0x...>
 
         """
-        import stability_function 
+        import nodepy.stability_function as stability_function
         import matplotlib.pyplot as plt
 
         p,q=self.__num__().stability_function(mode='float')
@@ -2026,13 +2029,13 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
 #=====================================================
 def elementary_weight(tree):
     """
-        Constructs Butcher's elementary weights 
+        Constructs Butcher's elementary weights
         for a Runge-Kutta method
 
         Currently doesn't work right; note that two of the 5th-order
         weights appear identical.  The _str version below works
-        correctly and produces NumPy code.  But it would be nice to 
-        have this version working so that we could symbolically 
+        correctly and produces NumPy code.  But it would be nice to
+        have this version working so that we could symbolically
         simplify the expressions.
 
         In order to do things correctly, we need a symbolic
@@ -2041,7 +2044,7 @@ def elementary_weight(tree):
             * Two different types of multiplication; or
             * Full tensor expressions
 
-        The latter is now available in Sympy, and I've started a 
+        The latter is now available in Sympy, and I've started a
         test implementation.  The main issue now is that things like
 
         AxA**2
@@ -2066,7 +2069,7 @@ def elementary_weight(tree):
             [butcher2003]_
     """
     #raise Exception('This function does not work correctly; use the _str version')
-    import rooted_trees as rt
+    import nodepy.rooted_trees as rt
     from sympy import symbols
     b=symbols('b',commutative=False)
     ew=b*tree.Gprod(RKeta,rt.Dmap)
@@ -2091,8 +2094,8 @@ def elementary_weight_str(tree,style='python'):
             >>> rk.elementary_weight_str(rt.RootedTree('{{T^11}T}'))
             'dot(b,dot(A,c**11))'
     """
-    from strmanip import mysimp
-    from rooted_trees import Dmap_str
+    from nodepy.strmanip import mysimp
+    from nodepy.rooted_trees import Dmap_str
     ewstr='dot(b,'+tree.Gprod_str(RKeta_str,Dmap_str)+')'
     ewstr=ewstr.replace('1*','')
     ewstr=mysimp(ewstr)
@@ -2103,7 +2106,7 @@ def elementary_weight_str(tree,style='python'):
 def RKeta(tree):
     from sympy.physics.quantum import TensorProduct
     #raise Exception('This function does not work correctly; use the _str version')
-    from rooted_trees import Dprod
+    from nodepy.rooted_trees import Dprod
     from sympy import symbols
     if tree=='':  return symbols('e',commutative=False)
     if tree=='T': return symbols('c',commutative=False)
@@ -2113,7 +2116,7 @@ def RKeta_str(tree):
     """
     Computes eta(t) for Runge-Kutta methods
     """
-    from rooted_trees import Dprod_str
+    from nodepy.rooted_trees import Dprod_str
     if tree=='':  return 'e'
     if tree=='T': return 'c'
     return 'dot(A,'+Dprod_str(tree,RKeta_str)+')'
@@ -2132,7 +2135,7 @@ def discrete_adjoint(meth):
     return RungeKuttaMethod(A,b)
 
 def is_absolutely_monotonic_poly(r,tol,p):
-    """ 
+    """
         Returns 1 if the polynomial p is absolutely monotonic
         at z=-r.
     """
@@ -2147,9 +2150,9 @@ def is_absolutely_monotonic_poly(r,tol,p):
 
 def shu_osher_change_alpha_ij(alpha,beta,i,j,val):
     """
-        **Input**: 
-            - alpha, beta: Shu-Osher arrays 
-            - i,j: indices 
+        **Input**:
+            - alpha, beta: Shu-Osher arrays
+            - i,j: indices
             - val -- real number
 
         **Output**: Shu-Osher arrays alph, bet with alph[i,j]=alpha[i,j]+val.
@@ -2170,11 +2173,11 @@ def shu_osher_zero_alpha_ij(alpha,beta,i,j):
 
 def shu_osher_zero_beta_ij(alpha,beta,i,j):
     """
-        **Input**: 
+        **Input**:
             - Shu-Osher arrays alpha, beta
             - indices i,j
 
-        **Output**: 
+        **Output**:
             - Shu-Osher arrays alph, bet with bet[i,j]=0.
     """
     t=-beta[i,j]/beta[j,j]
@@ -2183,14 +2186,14 @@ def shu_osher_zero_beta_ij(alpha,beta,i,j):
 
 def shu_osher_to_butcher(alpha,beta):
     r""" Accepts a Shu-Osher representation of an explicit Runge-Kutta
-        and returns the Butcher coefficients 
+        and returns the Butcher coefficients
 
         \\begin{align*}
         A = & (I-\\alpha_0)^{-1} \\beta_0 \\\\
         b = & \\beta_1 + \\alpha_1
         \\end{align*}
 
-        **References**:  
+        **References**:
              #. [gottlieb2009]_
     """
     if np.triu(alpha).any(): # Check that alpha is lower-triangular
@@ -2210,7 +2213,7 @@ def shu_osher_to_butcher(alpha,beta):
     return A,b
 
 def loadRKM(which='All'):
-    """ 
+    """
         Load a set of standard Runge-Kutta methods for testing.
         The following methods are included:
 
@@ -2218,13 +2221,13 @@ def loadRKM(which='All'):
 
         'FE':         Forward Euler
         'RK44':       Classical 4-stage 4th-order
-	'Merson43'    Merson 4(3) pair from Hairer and Wanner book pg. 167
+        'Merson43'    Merson 4(3) pair from Hairer and Wanner book pg. 167
         'MTE22':      Minimal truncation error 2-stage 2nd-order
         'Heun33':     Third-order method of Heun
         'SSP22':      Trapezoidal rule 2nd-order
         'DP5':        Dormand-Prince 5th-order
-	'CMR6':       Calvo et al.'s 6(5) method
-	'PD8':        Prince-Dormand 8th-order and 7th-order pair
+        'CMR6':       Calvo et al.'s 6(5) method
+        'PD8':        Prince-Dormand 8th-order and 7th-order pair
         'Fehlberg45': 5th-order part of Fehlberg's pair
         'Lambert65':
 
@@ -2585,15 +2588,15 @@ def loadRKM(which='All'):
 #============================================================
 
 def RK22_family(gamma):
-    """ 
-        Construct a 2-stage second order Runge-Kutta method 
+    """
+        Construct a 2-stage second order Runge-Kutta method
 
         **Input**: gamma -- family parameter
         **Output**: An ExplicitRungeKuttaMethod
         **Examples**::
 
             >>> from nodepy import rk
-            >>> print rk.RK22_family(-1)
+            >>> print(rk.RK22_family(-1))
             Runge-Kutta Method
             <BLANKLINE>
              0    |
@@ -2609,8 +2612,8 @@ def RK22_family(gamma):
     return ExplicitRungeKuttaMethod(A,b)
 
 def RK44_family(w):
-    """ 
-        Construct a 4-stage fourth order Runge-Kutta method 
+    """
+        Construct a 4-stage fourth order Runge-Kutta method
 
         **Input**: w -- family parameter
         **Output**: An ExplicitRungeKuttaMethod
@@ -2618,7 +2621,7 @@ def RK44_family(w):
         **Examples**::
 
             >>> from nodepy import rk
-            >>> print rk.RK44_family(1)
+            >>> print(rk.RK44_family(1))
             Runge-Kutta Method
             <BLANKLINE>
              0    |
@@ -2627,7 +2630,7 @@ def RK44_family(w):
              1    |       -2    3
             ______|________________________
                   | 1/6   -1/3  1     1/6
-                       
+
     """
     from sympy import Rational
     one = Rational(1,1)
@@ -2643,17 +2646,17 @@ def RK44_family(w):
 #============================================================
 
 def SSPRK2(m):
-    """ Construct the optimal m-stage, second order SSP 
+    """ Construct the optimal m-stage, second order SSP
         Explicit Runge-Kutta method (m>=2).
 
         **Input**: m -- number of stages
         **Output**: A ExplicitRungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> SSP42=SSPRK2(4)
-            >>> print SSP42
+            >>> print(SSP42)
             SSPRK(4,2)
             <BLANKLINE>
              0   |
@@ -2666,7 +2669,7 @@ def SSPRK2(m):
             >>> SSP42.absolute_monotonicity_radius()
             2.999999999974534
 
-        **References**: 
+        **References**:
             #. [ketcheson2008]_
     """
     from sympy import Rational
@@ -2683,9 +2686,9 @@ def SSPRK2(m):
 
 
 def SSPRK3(m):
-    """ 
+    """
         Construct the optimal m-stage third order SSP
-        Runge-Kutta method (m=n**2, n>=2) 
+        Runge-Kutta method (m=n**2, n>=2)
 
         **Input**: m -- number of stages
         **Output**: A RungeKuttaMethod
@@ -2694,7 +2697,7 @@ def SSPRK3(m):
 
             Load the 4-stage method:
             >>> SSP43=SSPRK3(4)
-            >>> print SSP43
+            >>> print(SSP43)
             SSPRK43
             <BLANKLINE>
              0   |
@@ -2707,7 +2710,7 @@ def SSPRK3(m):
             >>> SSP43.absolute_monotonicity_radius()
             1.9999999999527063
 
-        **References**: 
+        **References**:
             #. [ketcheson2008]_
     """
     from sympy import sqrt, Rational
@@ -2727,17 +2730,17 @@ def SSPRK3(m):
 
 
 def SSPRKm(m):
-    """ Construct the optimal m-stage, linearly mth order SSP 
+    """ Construct the optimal m-stage, linearly mth order SSP
         Explicit Runge-Kutta method (m>=2).
 
         **Input**: m -- number of stages
         **Output**: A ExplicitRungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> SSP44=SSPRKm(4)
-            >>> print SSP44
+            >>> print(SSP44)
             SSPRK44
             <BLANKLINE>
              0    |
@@ -2751,7 +2754,7 @@ def SSPRKm(m):
             >>> SSP44.absolute_monotonicity_radius()
             0.9999999999308784
 
-        **References**: 
+        **References**:
             #. [gottlieb2001]_
     """
     from sympy import factorial, Rational
@@ -2775,18 +2778,18 @@ def SSPRKm(m):
     return ExplicitRungeKuttaMethod(alpha=alpha,beta=beta,name=name,shortname=name)
 
 def SSPIRK1(m):
-    """ Construct the m-stage, first order unconditionally SSP 
-        Implicit Runge-Kutta method with smallest 
+    """ Construct the m-stage, first order unconditionally SSP
+        Implicit Runge-Kutta method with smallest
         coefficient of z^2 (in the stability polynomial)
 
         **Input**: m -- number of stages
         **Output**: A RungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> ISSP41=SSPIRK1(4)
-            >>> print ISSP41
+            >>> print(ISSP41)
             SSPIRK41
             <BLANKLINE>
              1/4 | 1/4
@@ -2803,17 +2806,17 @@ def SSPIRK1(m):
 
 
 def SSPIRK2(m):
-    """ Construct the optimal m-stage, second order SSP 
+    """ Construct the optimal m-stage, second order SSP
         Implicit Runge-Kutta method (m>=2).
 
         **Input**: m -- number of stages
         **Output**: A RungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> ISSP42=SSPIRK2(4)
-            >>> print ISSP42
+            >>> print(ISSP42)
             SSPIRK42
             <BLANKLINE>
              1/8 | 1/8
@@ -2839,17 +2842,17 @@ def SSPIRK2(m):
 
 
 def SSPIRK3(m):
-    """ Construct the optimal m-stage, third order SSP 
+    """ Construct the optimal m-stage, third order SSP
         Implicit Runge-Kutta method (m>=2).
 
         **Input**: m -- number of stages
         **Output**: A RungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> ISSP43=SSPIRK3(4)
-            >>> print ISSP43
+            >>> print(ISSP43)
             SSPIRK43
             <BLANKLINE>
              -sqrt(15)/10 + 1/2 | -sqrt(15)/10 + 1/2
@@ -2860,7 +2863,7 @@ def SSPIRK3(m):
                                 | 1/4                 1/4                 1/4                 1/4
 
             >>> x=ISSP43.absolute_monotonicity_radius()
-            >>> print "%.5f" % x
+            >>> print("{:.5f}".format(x))
             6.87298
 
         **References**:
@@ -2880,7 +2883,7 @@ def SSPIRK3(m):
 # Families of Runge-Kutta-Chebyshev methods
 #============================================================
 def RKC1(m,epsilon=0):
-    """ Construct the m-stage, first order 
+    """ Construct the m-stage, first order
         explicit Runge-Kutta-Chebyshev methods of Verwer (m>=1).
 
         'epsilon' is a damping parameter used to avoid tangency of the
@@ -2890,10 +2893,10 @@ def RKC1(m,epsilon=0):
         **Output**: A ExplicitRungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> RKC41=RKC1(4)
-            >>> print RKC41
+            >>> print(RKC41)
             Runge-Kutta-Chebyshev (4,1)
             <BLANKLINE>
              0    |
@@ -2903,7 +2906,7 @@ def RKC1(m,epsilon=0):
             ______|________________________
                   | 1/4   3/8   1/4   1/8
 
-        **References**: 
+        **References**:
             #. [verwer2004]_
     """
 
@@ -2953,20 +2956,20 @@ def RKC1(m,epsilon=0):
 
 
 def RKC2(m,epsilon=0):
-    """ Construct the m-stage, second order 
+    """ Construct the m-stage, second order
         Explicit Runge-Kutta-Chebyshev methods of Verwer (m>=2).
 
-        **Inputs**: 
+        **Inputs**:
                 m -- number of stages
                 epsilon -- damping factor
 
         **Output**: A ExplicitRungeKuttaMethod
 
         **Examples**::
-            
+
             Load the 4-stage method:
             >>> RKC42=RKC2(4)
-            >>> print RKC42
+            >>> print(RKC42)
             Runge-Kutta-Chebyshev (4,2)
             <BLANKLINE>
              0      |
@@ -2976,7 +2979,7 @@ def RKC2(m,epsilon=0):
             ________|________________________________
                     | -51/64  3/8     1       27/64
 
-        **References**: 
+        **References**:
             #. [verwer2004]_
     """
     import sympy
@@ -2997,7 +3000,7 @@ def RKC2(m,epsilon=0):
     nu=snp.zeros(m+1)
     mut=snp.zeros(m+1)
     gamt=snp.zeros(m+1)
-    
+
     T2 = sympy.special.polynomials.chebyshevt_poly(2,x)
     b[0]=sympy.Rational(T2.diff(x,2).subs(x,w0),(T2.diff().subs(x,w0))**2)
 
@@ -3056,7 +3059,7 @@ def DC_pair(s,theta=0.,grid='eq'):
 
             >>> from nodepy import rk
             >>> DC2 = rk.DC_pair(2)
-            >>> print DC2
+            >>> print(DC2)
             Picard 3(2)
             <BLANKLINE>
              0     |
@@ -3066,7 +3069,7 @@ def DC_pair(s,theta=0.,grid='eq'):
              1     | 1/6    2/3    1/6
             _______|___________________________________
                    | 1/6    0      0      2/3    1/6
-                   | 1/6    2/3    1/6                 
+                   | 1/6    2/3    1/6
     """
 
     if s<2:
@@ -3097,7 +3100,7 @@ def DC(s,theta=0,grid='eq',num_corr=None):
         is equal to s+1.
 
         **Examples**::
-            
+
             >>> from nodepy import rk
             >>> dc3 = rk.DC(3)
             >>> dc3.order()
@@ -3110,7 +3113,7 @@ def DC(s,theta=0,grid='eq',num_corr=None):
             >>> dc3_cheb.principal_error_norm() #doctest: +ELLIPSIS
             0.0066478...
 
-        **References**: 
+        **References**:
 
             #. [dutt2000]_
             #. [gottlieb2009]_
@@ -3176,7 +3179,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
 
             >>> from nodepy import rk
             >>> ex3 = rk.extrap(3)
-            >>> print ex3
+            >>> print(ex3)
             Ex-Euler 3
             <BLANKLINE>
              0   |
@@ -3194,7 +3197,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
             sqrt(11)/72
 
             >>> ex4 = rk.extrap(2,'midpoint')
-            >>> print ex4
+            >>> print(ex4)
             Ex-Midpoint 2
             <BLANKLINE>
              0    |
@@ -3207,8 +3210,8 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
 
             >>> ex4.order()
             4
- 
-        **References**: 
+
+        **References**:
 
             #. [Hairer]_ chapter II.9
     """
@@ -3268,7 +3271,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
                 beta[ J[j-1]+2+2*(i-1),J[j-1]+2*(i-1)+1] = 2/N[j]
                 beta[ J[j-1]+3+2*(i-1),J[j-1]+2*(i-1)+2] = 2/N[j]
 
-    
+
     #Really there are no more "stages", and we could form T_ss directly.
     #but it is simpler to add auxiliary stages and then reduce.
     if (embedded and p>2) or (not embedded):
@@ -3276,7 +3279,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
             #form T_{j+1,2}:
             alpha[nrs-1+j,J[j]-1] = 1 + 1/((N[j]/N[j-1])**an_exp - 1)
             alpha[nrs-1+j,J[j-1]-1] = - 1/((N[j]/N[j-1])**an_exp - 1)
-    
+
     #Now form all the rest, up to T_ss:
     nsd = nrs-1+p # Number of stages done
     for k in range(2,p-order_reducer):
@@ -3285,7 +3288,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
             alpha[nsd+ind,nsd-(p-k)+ind] = 1 + 1/((N[j]/N[j-k])**an_exp - 1)
             alpha[nsd+ind,nsd-(p-k)+ind-1] = - 1/((N[j]/N[j-k])**an_exp - 1)
         nsd += p-k
-      
+
     if shuosher:
         return alpha, beta
     else:
@@ -3294,7 +3297,7 @@ def extrap(p,base='euler',seq='harmonic',embedded=False, shuosher=False):
         return ExplicitRungeKuttaMethod(alpha=alpha,beta=beta,name=name,order=p).dj_reduce()
 
 def extrap_pair(p, base='euler'):
-    """ 
+    """
         Returns an embedded RK pair.  If the base method is Euler, the prinicpal method has
         order p and the embedded method has order p-1.  If the base
         method is midpoint, the orders are $2p, 2(p-1)$.
@@ -3336,18 +3339,18 @@ def extrap_pair(p, base='euler'):
         order = (2*p,2*(p-1))
     return ExplicitRungeKuttaPair(alpha=alpha1, beta=beta1, alphahat=alphahat, betahat=betahat, name=name, shortname=shortname, order=order).dj_reduce()
 
-   
+
 
 #============================================================
 # Miscellaneous functions
 #============================================================
 def runge_kutta_order_conditions(p,ind='all'):
-    """ 
+    """
         This is the current method of producing the code on-the-fly
         to test order conditions for RK methods.  May be deprecated
         soon.
     """
-    import rooted_trees as rt
+    import nodepy.rooted_trees as rt
     strings=rt.recursiveVectors(p,ind)
     code=[]
     for oc in strings:
@@ -3355,7 +3358,7 @@ def runge_kutta_order_conditions(p,ind='all'):
     return code
 
 def RKOCstr2code(ocstr):
-    """ 
+    """
         Converts output of runge_kutta_order_conditions() to
         numpy-executable code.
     """
@@ -3388,14 +3391,14 @@ def compose(RK1,RK2,h1=1,h2=1):
         What method is obtained by two successive FE steps?
         >>> from nodepy import rk
         >>> fe=rk.loadRKM('FE')
-        >>> print fe*fe
+        >>> print(fe*fe)
         Runge-Kutta Method
         <BLANKLINE>
          0     |
          0.500 | 0.500
         _______|______________
                | 0.500  0.500
-                
+
 
     TODO: Generalize this for any number of inputs
     """
@@ -3429,8 +3432,8 @@ def python_to_matlab(code):
     outline=outline.replace("dot(A,","(A*")
     outline=outline.replace("( c)","c")
     outline=outline.replace("-0","")
-    #print outline
-    #print '******************'
+    #print(outline)
+    #print('******************')
     return outline
 
 def relative_accuracy_efficiency(rk1,rk2,mode='float',tol=1.e-14):
@@ -3484,7 +3487,7 @@ def accuracy_efficiency(rk1,parallel=False,mode='float',tol=1.e-14,p=None):
         >>> rk.accuracy_efficiency(dp5) # doctest: +ELLIPSIS
         0.5264921944121...
     """
-    
+
     if p is None:
         p=rk1.order(mode=mode,tol=tol)
     A1=rk1.principal_error_norm(mode=mode,tol=tol)
@@ -3514,17 +3517,17 @@ def linearly_stable_step_size(rk, L, acc=1.e-7, tol=1.e-14, plot=1):
             >>> L1=semidisc.centered_diffusion_matrix(100)
             >>> L2=semidisc.centered_advection_diffusion_matrix(1.,1./500,100)
 
-            >>> print "%.5f" % rk.linearly_stable_step_size(rk44,L1,plot=0)
+            >>> print("{:.5f}".format(rk.linearly_stable_step_size(rk44,L1,plot=0)))
             0.00007
-            >>> print "%.5f" % rk.linearly_stable_step_size(rk44,L2,plot=0)
+            >>> print("{:.5f}".format(rk.linearly_stable_step_size(rk44,L2,plot=0)))
             0.02423
 
             >>> sd = semidisc.load_semidisc('spectral difference advection',order=1)
-            >>> print "%.5f" % rk.linearly_stable_step_size(rk44,sd.L,plot=0)
+            >>> print("{:.5f}".format(rk.linearly_stable_step_size(rk44,sd.L,plot=0)))
             0.01393
     """
 
-    from utils import bisect
+    from nodepy.utils import bisect
     import matplotlib.pyplot as plt
 
     p,q = rk.__num__().stability_function(mode='float')
@@ -3578,7 +3581,7 @@ def _stability_function(alpha,beta,explicit,m,formula,mode='exact'):
     else: # Compute symbolically
         import sympy
         z = sympy.var('z')
-        
+
         if explicit:
             v = 1 - alpha[:,1:].sum(1)
             alpha[:,0]=0.
@@ -3627,7 +3630,7 @@ def _stability_function(alpha,beta,explicit,m,formula,mode='exact'):
             p1 = p1*vstar
             p1 = sympy.poly(p1[0])+v_mp1
             p1 = p1.all_coeffs()
-            
+
 
         else:
             raise Exception("Unknown value of 'formula'")
@@ -3641,10 +3644,10 @@ def _stability_function(alpha,beta,explicit,m,formula,mode='exact'):
 
     return p,q
 
- 
+
 
 def _internal_stability_polynomials(alpha,beta,explicit,m,formula,mode='exact'):
-    r""" 
+    r"""
         Compute internal stability polynomials from a Shu-Osher representation.
     """
     s = alpha.shape[1]

--- a/nodepy/snp.py
+++ b/nodepy/snp.py
@@ -5,7 +5,7 @@ that understand numpy arrays of floats or symbolic objects.
 import sympy
 import numpy as np
 
-dtypes={'exact':object,'numeric':np.float64}
+dtypes = {'exact': object, 'numeric': np.float64}
 
 def normalize(*arrays):
     """
@@ -34,7 +34,7 @@ def tri(n,mode='exact'):
     return x
 
 def solve(A,b):
-    """Solve Ax = b.  
+    """Solve Ax = b.
         If A holds exact values, solve exactly using sympy.
         Otherwise, solve in floating-point using numpy.
     """
@@ -66,8 +66,8 @@ def linspace(start,stop,num=50,endpoint=True,retstep=False):
 def arange(start,stop=None,step=None,mode='exact'):
     return normalize(np.arange(start,stop,step,dtype=dtypes[mode]))
 
-def zeros(shape,mode='exact'):
-    return normalize(np.zeros(shape,dtype=dtypes[mode]))
+def zeros(shape, mode='exact'):
+    return normalize(np.zeros(np.array(shape).astype(int), dtype=dtypes[mode]))
 
 def diag(v, k=0):
     return normalize(np.diag(v,k))
@@ -87,7 +87,7 @@ def array(x):
 
 def simplify(x):
     shape = x.shape
-    x = map(sympy.simplify,x.reshape(-1))
+    x = list(map(sympy.simplify, x.reshape(-1)))
     return np.reshape(x,shape)
 
 def printable(num,digits=3,return_zero=False,return_one=True):

--- a/nodepy/stability_function.py
+++ b/nodepy/stability_function.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import numpy as np
 
 def imaginary_stability_interval(p,q=None,eps=1.e-14):
@@ -12,7 +14,7 @@ def imaginary_stability_interval(p,q=None,eps=1.e-14):
             >>> rk4.imaginary_stability_interval() #doctest: +ELLIPSIS
             2.8284271247...
     """
-    if q is None: 
+    if q is None:
         q = np.poly1d([1.])
 
     c = p.c[::-1].copy()
@@ -68,7 +70,7 @@ def imaginary_stability_interval(p,q=None,eps=1.e-14):
         else:
             return 0
         if np.abs(z)<1.e-10:
-            print "Warning: unable to determine exact imaginary stability interval"
+            print("Warning: unable to determine exact imaginary stability interval")
             return mr
 
 
@@ -82,7 +84,7 @@ def real_stability_interval(p,q=None,eps=1.e-12):
             >>> from nodepy import rk
             >>> rk4 = rk.loadRKM('RK44')
             >>> I = rk4.real_stability_interval()
-            >>> print "%.10f" % I
+            >>> print("{:.10f}".format(I))
             2.7852935634
             >>> rkc = rk.RKC1(2)
             >>> rkc.real_stability_interval()
@@ -106,7 +108,7 @@ def real_stability_interval(p,q=None,eps=1.e-12):
         z = -(roots[i]+roots[i+1])/2
         if np.abs(p(z)/q(z))>1.+eps:
             return roots[i]
-    z = -roots[-1]*2 
+    z = -roots[-1]*2
     if np.abs(p(z)/q(z))>1.+eps:
         return roots[-1]
     return np.inf
@@ -114,7 +116,7 @@ def real_stability_interval(p,q=None,eps=1.e-12):
 
 def plot_stability_region(p,q,N=200,color='r',filled=True,bounds=None,
                           plotroots=False,alpha=1.,scalefac=1.,fignum=None):
-    r""" 
+    r"""
         Plot the region of absolute stability of a rational function; i.e. the set
 
         `\{ z \in C : |\phi (z)|\le 1 \}`
@@ -122,11 +124,11 @@ def plot_stability_region(p,q,N=200,color='r',filled=True,bounds=None,
         Unless specified explicitly, the plot bounds are determined automatically, attempting to
         include the entire region.  A check is performed beforehand for
         methods with unbounded stability regions.
-        Note that this function is not responsible for actually drawing the 
+        Note that this function is not responsible for actually drawing the
         figure to the screen (or saving it to file).
 
-        **Inputs**: 
-            - p, q  -- Numerator and denominator of the stability function 
+        **Inputs**:
+            - p, q  -- Numerator and denominator of the stability function
             - N       -- Number of gridpoints to use in each direction
             - color   -- color to use for this plot
             - filled  -- if true, stability region is filled in (solid); otherwise it is outlined
@@ -145,11 +147,11 @@ def plot_stability_region(p,q,N=200,color='r',filled=True,bounds=None,
         q = np.poly1d([float(c) for c in q.coeffs])
 
     if bounds is None:
-        from utils import find_plot_bounds
+        from nodepy.utils import find_plot_bounds
         # Check if the stability region is bounded or not
         m,n = p.order,q.order
         if (m < n) or ((m == n) and (abs(p[m])<abs(q[n]))):
-            print 'The stability region is unbounded'
+            print('The stability region is unbounded')
             if m > 0:
                 bounds = (-10*m,m,-5*m,5*m)
             else:
@@ -158,10 +160,10 @@ def plot_stability_region(p,q,N=200,color='r',filled=True,bounds=None,
             stable = lambda z : np.abs(p(z)/q(z))<=1.0
             bounds = find_plot_bounds(stable,guess=(-10,1,-5,5))
             if np.min(np.abs(np.array(bounds)))<1.e-14:
-                print 'No stable region found; is this method zero-stable?'
+                print('No stable region found; is this method zero-stable?')
 
         if (m == n) and (abs(p[m])==abs(q[n])):
-            print 'The stability region may be unbounded'
+            print('The stability region may be unbounded')
 
     # Evaluate the stability function over a grid
     x=np.linspace(bounds[0],bounds[1],N)
@@ -191,7 +193,7 @@ def plot_order_star(p,q,N=200,bounds=[-5,5,-5,5], plotroots=False,
                 color=('w','b'),filled=True,fignum=None):
     r""" Plot the order star of a rational function
         i.e. the set
-        
+
         $$ \{ z \in C : |R(z)/exp(z)|\le 1 \} $$
 
         where $R(z)=p(z)/q(z)$ is the stability function of the method.

--- a/nodepy/twostep_runge_kutta_method.py
+++ b/nodepy/twostep_runge_kutta_method.py
@@ -13,14 +13,14 @@ with the rest of nodepy.
     >>> tsrk4 = tsrk.loadTSRK('order4')
     >>> tsrk5 = tsrk.loadTSRK('order5')
 
-    >>> print tsrk4
+    >>> print(tsrk4)
     Two-step Runge-Kutta Method
     General
      -113/88      | 1435/352      -479/352      | 1
      -103/88      | 1917/352      -217/352      |               1
     ______________|_____________________________|_____________________________
     -4483/8011    | 180991/96132  -17777/32044  | -44709/32044  48803/96132
-    >>> print tsrk4.latex()
+    >>> print(tsrk4.latex())
     \begin{align}
       \begin{array}{c|cc|cc}
       - \frac{113}{88} & \frac{1435}{352} & - \frac{479}{352} & 1 & 0\\
@@ -51,12 +51,15 @@ with the rest of nodepy.
     [jackiewicz1995,butcher1997,hairer1997]
 
 """
+from __future__ import print_function
 from __future__ import division
-from general_linear_method import GeneralLinearMethod
+
 import numpy as np
-import rooted_trees as rt
-from strmanip import *
-import snp
+
+import nodepy.rooted_trees as rt
+import nodepy.snp as snp
+from nodepy.strmanip import *
+from nodepy.general_linear_method import GeneralLinearMethod
 
 #=====================================================
 class TwoStepRungeKuttaMethod(GeneralLinearMethod):
@@ -92,7 +95,7 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
         self.type=type
 
     def order(self,tol=1.e-13):
-        r""" 
+        r"""
             Return the order of a Two-step Runge-Kutta method.
             Computed by computing the elementary weights corresponding
             to the appropriate rooted trees.
@@ -135,7 +138,7 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
 
 
     def stability_matrix(self,z):
-        r""" 
+        r"""
             Constructs the stability matrix of a two-step Runge-Kutta method.
             Right now just for a specific value of z.
             We ought to use Sage to do it symbolically.
@@ -192,7 +195,7 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
 
     def plot_stability_region(self,N=50,bounds=None,
                     color='r',filled=True,scaled=False):
-        r""" 
+        r"""
             Plot the region of absolute stability
             of a Two-step Runge-Kutta method, i.e. the set
 
@@ -210,11 +213,11 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
 
         import matplotlib.pyplot as plt
         if bounds is None:
-            from utils import find_plot_bounds
+            from nodepy.utils import find_plot_bounds
             stable = lambda z : max(abs(np.linalg.eigvals(method.stability_matrix(z))))<=1.0
             bounds = find_plot_bounds(np.vectorize(stable),guess=(-10,1,-5,5))
             if np.min(np.abs(np.array(bounds)))<1.e-14:
-                print 'No stable region found; is this method zero-stable?'
+                print('No stable region found; is this method zero-stable?')
 
         x=np.linspace(bounds[0],bounds[1],N)
         y=np.linspace(bounds[2],bounds[3],N)
@@ -239,17 +242,17 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
 
     def absolute_monotonicity_radius(self,acc=1.e-10,rmax=200,
                     tol=3.e-16):
-        r""" 
+        r"""
             Returns the radius of absolute monotonicity
             of a TSRK method.
         """
-        from utils import bisect
+        from nodepy.utils import bisect
         r=bisect(0,rmax,acc,tol,self.is_absolutely_monotonic)
         return r
 
     def latex(self):
-    	"""A laTeX representation of the compact form."""
-    	from sympy.printing import latex
+        """A laTeX representation of the compact form."""
+        from sympy.printing import latex
 
         d       = self.d
         A       = self.A
@@ -262,17 +265,17 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
         s+='\n'
         s+=r'  \begin{array}{c|'
         s+='c'*(len(self)) +'|'
-        s+='c'*(len(self)) 
+        s+='c'*(len(self))
         s+='}\n'
         for i in range(len(self)):
             s+='  '+latex(d[i])
-            
+
             for j in range(len(self)):
                 s+=' & '+latex(Ahat[i,j])
-            
+
             for j in range(len(self)):
                 s+=' & '+latex(A[i,j])
-            
+
             s+=r'\\'
             s+='\n'
         s+=r'  \hline'
@@ -287,21 +290,21 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
         s+='\n'
         s+=r'\end{align}'
         s=s.replace('- -','')
-    	return s
+        return s
 
 
     def __str__(self):
-	from nodepy.utils import array2strings
-	from runge_kutta_method import _get_column_widths
-        
+        from nodepy.utils import array2strings
+        from nodepy.runge_kutta_method import _get_column_widths
+
         d       = array2strings(self.d)
         A       = array2strings(self.A)
         Ahat    = array2strings(self.Ahat)
         b       = array2strings(self.b)
         bhat    = array2strings(self.bhat)
 
-	theta = str(self.theta)
-	lenmax, colmax = _get_column_widths([d, Ahat, A, bhat, b])
+        theta = str(self.theta)
+        lenmax, colmax = _get_column_widths([d, Ahat, A, bhat, b])
 
         s   = self.name+'\n'+self.type+'\n'
         for i in range(len(self)):
@@ -365,8 +368,8 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
             T1 =  np.hstack([ahat,self.A,np.zeros([s,1])])
             T2 =  np.hstack([bh,self.b.T,np.zeros([1,1])])
             T = np.vstack([T0,T1,T2])
-            
-        return S,T
+
+        return S.astype(np.float64), T.astype(np.float64)
 
 
     def is_absolutely_monotonic(self,r,tol):
@@ -383,12 +386,13 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
             **References**:
                 #. [spijker2007]
         """
-        S,T = self.spijker_form()
-        m=np.shape(T)[0]
-        X=np.eye(m)+r*T
-        if abs(np.linalg.det(X))<tol: return 0
-        P = np.linalg.solve(X,T)
-        R = np.linalg.solve(X,S)
+        S, T = self.spijker_form()
+        m = np.shape(T)[0]
+        X = np.eye(m) + r * T
+        if abs(np.linalg.det(X)) < tol:
+            return 0
+        P = np.linalg.solve(X, T)
+        R = np.linalg.solve(X, S)
         if P.min()<-tol or R.min()<-tol:
             return 0
         else:
@@ -401,7 +405,7 @@ class TwoStepRungeKuttaMethod(GeneralLinearMethod):
 #================================================================
 
 def TSRKOrderConditions(p,ind='all'):
-    from rooted_trees import Emap_str
+    from nodepy.rooted_trees import Emap_str
     forest=rt.list_trees(p)
     code=[]
     for tree in forest:
@@ -413,7 +417,7 @@ def TSRKOrderConditions(p,ind='all'):
 
 def tsrk_elementary_weight(tree):
     """
-        Constructs Butcher's elementary weights 
+        Constructs Butcher's elementary weights
         for Two-step Runge-Kutta methods
     """
     from sympy import Symbol
@@ -423,17 +427,17 @@ def tsrk_elementary_weight(tree):
 
 def tsrk_elementary_weight_str(tree):
     """
-        Constructs Butcher's elementary weights 
+        Constructs Butcher's elementary weights
         for Two-step Runge-Kutta methods
         as numpy-executable strings
     """
-    from rooted_trees import Dmap_str, Emap_str
+    from nodepy.rooted_trees import Dmap_str, Emap_str
     ewstr='dot(bhat,'+tree.Gprod_str(rt.Emap_str,rt.Gprod_str,betaargs=[TSRKeta_str,Dmap_str],alphaargs=[-1])+')+dot(b,'+tree.Gprod_str(TSRKeta_str,rt.Dmap_str)+')+theta*'+Emap_str(tree,-1)
     ewstr=mysimp(ewstr)
     return ewstr
 
 def TSRKeta(tree):
-    from rooted_trees import Dprod
+    from nodepy.rooted_trees import Dprod
     from sympy import symbols
     raise Exception('This function does not work correctly; use the _str version')
     if tree=='':  return 1
@@ -444,7 +448,7 @@ def TSRKeta_str(tree):
     """
     Computes eta(t) for Two-step Runge-Kutta methods
     """
-    from rooted_trees import Dprod_str, Emap_str
+    from nodepy.rooted_trees import Dprod_str, Emap_str
     if tree=='':  return 'e'
     if tree=='T': return 'c'
     return '(d*'+Emap_str(tree,-1)+'+dot(Ahat,'+tree.Gprod_str(Emap_str,Dprod_str,betaargs=[TSRKeta_str],alphaargs=[-1])+')'+'+dot(A,'+Dprod_str(tree,TSRKeta_str)+'))'
@@ -496,7 +500,7 @@ def loadTSRK(which='All'):
 def load_type2_TSRK(s,p,type='Type II'):
     r"""
     Load a TSRK method from its coefficients in an ASCII file
-    (usually from MATLAB).  The coefficients are stored in the 
+    (usually from MATLAB).  The coefficients are stored in the
     following order: [s d theta A b Ahat bhat].
     """
     path='/Users/ketch/Research/Projects/MRK/methods/TSRK/'

--- a/nodepy/unit_tests.py
+++ b/nodepy/unit_tests.py
@@ -2,8 +2,8 @@
 Unit tests for NodePy.
 This needs to be updated.
 """
-import linear_multistep_method as lmm
-import runge_kutta_method as rk
+import nodepy.linear_multistep_method as lmm
+import nodepy.runge_kutta_method as rk
 import unittest as ut
 
 class LinearMultistepTestCase(ut.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -6,7 +6,7 @@ import nodepy
 matplotlib.use('agg')
 import unittest
 
-for module_name in ('runge_kutta_method',
+for module_name in ['runge_kutta_method',
                     'linear_multistep_method',
                     'twostep_runge_kutta_method',
                     'downwind_runge_kutta_method',
@@ -21,7 +21,7 @@ for module_name in ('runge_kutta_method',
                     'strmanip',
                     'utils',
                     'graph',
-                    'convergence'):
+                    'convergence']:
     module = nodepy.__getattribute__(module_name)
     doctest.testmod(module)
 


### PR DESCRIPTION
I ported all the code to Python 3. Tested with 3.5, numpy 1.11 and sympy 1.0 to be exact, but it should work with previous versions as well. Still works with Python 2.7 too.

All the tests pass locally, so hopefully it's ok. The biggest changes are:
* the print function
* the fact that range, map, etc return iterators in Python 3
* fixed some tests regarding dicts that expected a certain order (sorted the dict keys beforehand)
* fixed some __step__ methods that used t[-1], but the t passed in ode_solver seems to always be a scalar
* the __num__ method only checked that A was an object, but the low-storage scheme had A as float64, but b was still an object
* some changes related to the newer version of numpy

I'm afraid there are quite a few unrelated changes (also whitespace), hopefully that's not too big of an issue.