### PR TITLE
Feature: added TR-BDF2 DIRK method 

### DIFF
--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -21,7 +21,7 @@
 
     >>> RK=loadRKM()
     >>> sorted(RK.keys())
-    ['BE', 'BS5', 'BuRK65', 'CMR6', 'DP5', 'FE', 'Fehlberg45', 'GL2', 'GL3', 'Heun33', 'Lambert65', 'LobattoIIIA2', 'LobattoIIIA3', 'LobattoIIIC2', 'LobattoIIIC3', 'LobattoIIIC4', 'MTE22', 'Merson43', 'Mid22', 'NSSP32', 'NSSP33', 'PD8', 'RK44', 'RadauIIA2', 'RadauIIA3', 'SDIRK23', 'SDIRK34', 'SDIRK54', 'SSP104', 'SSP22', 'SSP22star', 'SSP33', 'SSP53', 'SSP54', 'SSP63', 'SSP75', 'SSP85', 'SSP95']
+    ['BE', 'BS5', 'BuRK65', 'CMR6', 'DP5', 'FE', 'Fehlberg45', 'GL2', 'GL3', 'Heun33', 'Lambert65', 'LobattoIIIA2', 'LobattoIIIA3', 'LobattoIIIC2', 'LobattoIIIC3', 'LobattoIIIC4', 'MTE22', 'Merson43', 'Mid22', 'NSSP32', 'NSSP33', 'PD8', 'RK44', 'RadauIIA2', 'RadauIIA3', 'SDIRK23', 'SDIRK34', 'SDIRK54', 'SSP104', 'SSP22', 'SSP22star', 'SSP33', 'SSP53', 'SSP54', 'SSP63', 'SSP75', 'SSP85', 'SSP95', 'TR-BDF2']
 
     >>> print(RK['Mid22'])
     Midpoint Runge-Kutta
@@ -2428,6 +2428,14 @@ def loadRKM(which='All'):
     RK['SDIRK34'] = RungeKuttaMethod(A, b, name='SDIRK34',
                         description=r"4th-order SDIRK method of Norsett",
                         shortname = 'SDIRK34')
+
+    #================================================
+    # This method is from Bank et al. 1985
+    A=snp.array([[0,0,0],[one/4,one/4,0],[one/3,one/3,one/3]])
+    b=snp.array([one/3,one/3,one/3])
+    description=r"2nd-order, L-stable DIRK method of Bank et al."
+    RK['TR-BDF2'] = RungeKuttaMethod(A, b, name='TR-BDF2',
+                        description=description, shortname='TR-BDF2')
 
     #================================================
     # SSP methods


### PR DESCRIPTION
Implemented the one-step, 2nd-order, L-stable, diagonally implicit Runge-Kutta TR-BDF2 method from R. Bank et al., "Transient Simulation of Silicon Devices and Circuits", _IEEE Transactions on Computer-Aided Design of Integrated Circuits and Systems_, October 1985, Vol. 4(4), pp. 436-451.  

The following code generates the output and figures below.

```python
from nodepy.runge_kutta_method import *
trbdf2 = loadRKM('TR-BDF2')
print(trbdf2)
trbdf2.plot_stability_region(bounds=[-15,15,-15,15])
trbdf2.plot_order_star()
```

```
TR-BDF2
2nd-order, L-stable DIRK method of Bank et al.
 0   |
 1/2 | 1/4  1/4
 1   | 1/3  1/3  1/3
____ |_______________
     | 1/3  1/3  1/3
```

<img src="https://user-images.githubusercontent.com/20851558/41116975-c868aa9e-6a59-11e8-839e-7906ae3689f5.png" height="240" width="320" ><img src="https://user-images.githubusercontent.com/20851558/41116983-cdfdcfca-6a59-11e8-8cd1-9f4dde8436a9.png" height="240" width="320" >