### PR TITLE
Plot Controller Stability

### DIFF
--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -2166,8 +2166,8 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
             ax1.set_title('Stability region')
             plt.suptitle(self.shortname)
 
-        # Plot I controller stability function.
-        v = c.collections[0].get_paths()[0].vertices
+        # Plot I, PI, PID controller stability function
+        v = np.vstack([p.vertices for p in c.collections[0].get_paths()])
         xx = v[:,0]
         yy = v[:,1]
         zz = (xx + 1j * yy) * scalefac

--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -2187,7 +2187,17 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
                                     to_file=False, longtitle=True, fignum=None):
         r"""Plot the absolute stability region and the function characterizing
             stepsize control stability for an I controller of an RK pair,
-            cf. :cite:`hairerODEs2`.
+            cf. :cite:`hairerODEs2`. The I controller is of the form
+
+            .. math::
+
+                \begin{equation}
+                    h_{n+1} = \left(\frac{\mathrm{TOL}}{\mathrm{err}_{n}})^{1/k} h_{n},
+                \end{equation}
+
+            where `h` is the stepsize, `TOL` the tolerance, and `err = O(h^k)`
+            the error estimate.
+
             By default, the region of the main method is filled in red and the
             region of the embedded method is outlined in black.
 
@@ -2223,6 +2233,75 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
             ax2.set_title("I Controller Stability Function")
         else:
             ax2.set_title("I Controller")
+
+        asp = np.diff(ax2.get_xlim())[0] / np.diff(ax2.get_ylim())[0]
+        ax2.set_aspect(asp)
+
+        # Save or draw the plot.
+        fig.tight_layout()
+        if to_file:
+            plt.savefig(to_file, transparent=True, bbox_inches='tight', pad_inches=0.3)
+        else:
+            plt.draw()
+
+        return fig
+
+    def plot_PI_controller_stability(self, beta1=2./3., beta2=-1./3.,
+                                     N=200, color='r', filled=True, bounds=None,
+                                     plotroots=False, alpha=1., scalefac=1.,
+                                     to_file=False, longtitle=True, fignum=None):
+        r"""Plot the absolute stability region and the function characterizing
+            stepsize control stability for an PI controller of an RK pair,
+            cf. :cite:`hairerODEs2`. The PI controller is of the form
+
+            .. math::
+
+                \begin{equation}
+                    h_{n+1} = \left(\frac{\mathrm{TOL}}{\mathrm{err}_{n}})^{\beta_1/k} \left(\frac{\mathrm{TOL}}{\mathrm{err}_{n-1}})^{\beta_2/k} h_{n},
+                \end{equation}
+
+            where `h` is the stepsize, `TOL` the tolerance, and `err = O(h^k)`
+            the error estimate.
+
+            By default, the region of the main method is filled in red and the
+            region of the embedded method is outlined in black.
+
+            **Example**::
+
+                >>> from nodepy import rk
+                >>> bs5 = rk.loadRKM('BS5')
+                >>> bs5.plot_I_controller_stability() # doctest: +ELLIPSIS
+                <matplotlib.figure.Figure object at 0x...>
+        """
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        fig, ax1, ax2, angle, zRprime_R, zEprime_E = self._plot_controller_stability_common(
+            N=N, color=color, filled=filled, bounds=bounds, plotroots=plotroots, alpha=alpha,
+            scalefac=scalefac, to_file=to_file, longtitle=longtitle, fignum=fignum)
+
+        # Plot I controller stability function, see :cite:`hairerODEs2`, pp. 24f.
+        k = min(self.main_method.p, self.embedded_method.p) + 1.0
+
+        C = np.zeros((np.size(angle), 4, 4))
+        C[:,0,0] = 1
+        C[:,0,1] = zRprime_R
+        C[:,1,0] = -beta1/k
+        C[:,1,1] = 1 - beta1/k * zEprime_E
+        C[:,1,2] = -beta2/k
+        C[:,1,3] = -beta2/k * zEprime_E
+        C[:,2,0] = 1
+        C[:,3,1] = 1
+        rho = np.abs(np.linalg.eigvals(C)).max(axis=1)
+
+        ax2.plot(angle, rho)
+        ax2.plot(angle, np.ones(np.size(rho)), '--k', linewidth=2)
+        ax2.set_xticks([np.pi/2, np.pi*5/8, np.pi*3/4, np.pi*7/8, np.pi])
+        ax2.set_xticklabels(['$\pi/2$', '$5\pi/8$', '$3\pi/4$', '$7\pi/8$', '$\pi$'])
+        if longtitle:
+            ax2.set_title("PI Controller Stability Function\n($\\beta_1 = %.2f, \\beta_2 = %.2f$)" % (beta1, beta2))
+        else:
+            ax2.set_title("PI Controller")
 
         asp = np.diff(ax2.get_xlim())[0] / np.diff(ax2.get_ylim())[0]
         ax2.set_aspect(asp)

--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -2124,6 +2124,10 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
             m, n = num.order, den.order
             stable = lambda z : np.abs(num(z) / den(z)) <= 1.0
             bounds = find_plot_bounds(stable, guess=(-10,1,-5,5))
+            max_extent = 0.5 * max(bounds[1]-bounds[0], bounds[3]-bounds[2])
+            xmid = 0.5 * (bounds[0] + bounds[1])
+            ymid = 0.5 * (bounds[2] + bounds[3])
+            bounds = [xmid - max_extent, xmid + max_extent, ymid - max_extent, ymid + max_extent]
             if np.min(np.abs(np.array(bounds))) < 1.e-14:
                 print('No stable region found; is this method zero-stable?')
 
@@ -2182,7 +2186,8 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
 
         return fig, ax1, ax2, angle, zRprime_R, zEprime_E
 
-    def plot_I_controller_stability(self, N=200, color='r', filled=True, bounds=None,
+    def plot_I_controller_stability(self, beta1=1.,
+                                    N=200, color='r', filled=True, bounds=None,
                                     plotroots=False, alpha=1., scalefac=1.,
                                     to_file=False, longtitle=True, fignum=None):
         r"""Plot the absolute stability region and the function characterizing
@@ -2192,7 +2197,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
             .. math::
 
                 \begin{equation}
-                    h_{n+1} = \left(\frac{\mathrm{TOL}}{\mathrm{err}_{n}})^{1/k} h_{n},
+                    h_{n+1} = \left(\frac{\mathrm{TOL}}{\mathrm{err}_{n}})^{\beta_1/k} h_{n},
                 \end{equation}
 
             where `h` is the stepsize, `TOL` the tolerance, and `err = O(h^k)`
@@ -2230,7 +2235,7 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
         ax2.set_xticks([np.pi/2, np.pi*5/8, np.pi*3/4, np.pi*7/8, np.pi])
         ax2.set_xticklabels(['$\pi/2$', '$5\pi/8$', '$3\pi/4$', '$7\pi/8$', '$\pi$'])
         if longtitle:
-            ax2.set_title("I Controller Stability Function")
+            ax2.set_title("I Controller Stability Function\n($\\beta_1 = %.2f$)" % (beta1))
         else:
             ax2.set_title("I Controller")
 
@@ -2372,9 +2377,9 @@ class ExplicitRungeKuttaPair(ExplicitRungeKuttaMethod):
         ax2.set_xticks([np.pi/2, np.pi*5/8, np.pi*3/4, np.pi*7/8, np.pi])
         ax2.set_xticklabels(['$\pi/2$', '$5\pi/8$', '$3\pi/4$', '$7\pi/8$', '$\pi$'])
         if longtitle:
-            ax2.set_title("PI Controller Stability Function\n($\\beta_1 = %.2f, \\beta_2 = %.2f$)" % (beta1, beta2))
+            ax2.set_title("PID Controller Stability Function\n($\\beta_1 = %.2f, \\beta_2 = %.2f, \\beta_3 = %.2f$)" % (beta1, beta2, beta3))
         else:
-            ax2.set_title("PI Controller")
+            ax2.set_title("PID Controller")
 
         asp = np.diff(ax2.get_xlim())[0] / np.diff(ax2.get_ylim())[0]
         ax2.set_aspect(asp)


### PR DESCRIPTION
I've added some functions to plot the I, PI, and PID controller stability functions for explicit Runge-Kutta methods. For example, you can now run
```python
In [1]: import nodepy.runge_kutta_method as rkm

In [2]: %pylab
Using matplotlib backend: TkAgg
Populating the interactive namespace from numpy and matplotlib

In [3]: dp5 = rkm.loadRKM('DP5')

In [4]: dp5.plot_I_controller_stability()
Out[4]: <Figure size 640x480 with 2 Axes>

In [5]: dp5.plot_PI_controller_stability()
Out[5]: <Figure size 640x480 with 2 Axes>

In [6]: dp5.plot_PID_controller_stability()
Out[6]: <Figure size 640x480 with 2 Axes>
```