### PR TITLE
fix Shu-Osher coefficients of SSP22 and SSP33

### DIFF
--- a/nodepy/runge_kutta_method.py
+++ b/nodepy/runge_kutta_method.py
@@ -2761,8 +2761,8 @@ def loadRKM(which='All'):
             "The optimal 2-stage, 2nd order SSP Runge-Kutta method, also known as Heun's 2nd order method",shortname='SSPRK22')
     RK['SSP22']  = ssp22
     RK['Heun22'] = ssp22
-    RK['SSP22'].alpha = np.array([[0,0,0],[one,0,0],[one/2,one/2,0]])
-    RK['SSP22'].beta = np.array([[0,0,0],[one,0,0],[0,one/2,0]])
+    RK['SSP22'].alpha = np.array([[0,0],[one,0],[one/2,one/2]])
+    RK['SSP22'].beta = np.array([[0,0],[one,0],[0,one/2]])
 
     #================================================
     A=np.array([[0,0,0],[one,0,0],[one/4,one/4,0]])
@@ -2771,8 +2771,8 @@ def loadRKM(which='All'):
     RK['SSP33']=ExplicitRungeKuttaPair(A,b,bhat=bhat,name='SSPRK 33',
                 description=
                 "The optimal 3-stage, 3rd order SSP Runge-Kutta method",shortname='SSPRK33')
-    RK['SSP33'].alpha = np.array([[0,0,0,0],[one,0,0,0],[3*one/4,one/4,0,0],[one/3,0,2*one/3,0]])
-    RK['SSP33'].beta = np.array([[0,0,0,0],[one,0,0,0],[0,one/4,0,0],[0,0,2*one/3,0]])
+    RK['SSP33'].alpha = np.array([[0,0,0],[one,0,0],[3*one/4,one/4,0],[one/3,0,2*one/3]])
+    RK['SSP33'].beta = np.array([[0,0,0],[one,0,0],[0,one/4,0],[0,0,2*one/3]])
 
     #================================================
     A=np.array([[0,0,0],[one/3,0,0],[0,2*one/3,0]])


### PR DESCRIPTION
This bug was introduced in 976f5ec4102b4426f7a541d36ac8b81e8a95d0a2. On `master`:
```python
In [1]: from nodepy import *                                                                                     

In [2]: erk = rk.loadRKM("SSP22"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha
   ...: , beta=erk.beta) == erk                                                                                  
[[0 0 0]
 [1 0 0]
 [1/2 1/2 0]]
[[0 0 0]
 [1 0 0]
 [0 1/2 0]]
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-2-15687fa33ef3> in <module>
----> 1 erk = rk.loadRKM("SSP22"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha, beta=erk.beta) == erk

~/Software/nodepy/nodepy/runge_kutta_method.py in __init__(self, A, b, alpha, beta, name, shortname, description, mode, order)
    138                      'Inconsistent dimensions of Butcher arrays')
    139         elif shu_osher:
--> 140             A,b=shu_osher_to_butcher(alpha,beta)
    141         # Set Butcher arrays
    142         if len(np.shape(A))==2: self.A=A

~/Software/nodepy/nodepy/runge_kutta_method.py in shu_osher_to_butcher(alpha, beta)
   2558     if not np.all([np.size(alpha,0),np.size(beta,0),
   2559                     np.size(beta,1)]==[m+1,m+1,m]):
-> 2560         raise Exception('Inconsistent dimensions of Shu-Osher arrays')
   2561 
   2562     alph = snp.zeros( (m+1,m+1) )

Exception: Inconsistent dimensions of Shu-Osher arrays

In [3]: erk = rk.loadRKM("SSP33"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha
   ...: , beta=erk.beta) == erk                                                                                  
[[0 0 0 0]
 [1 0 0 0]
 [3/4 1/4 0 0]
 [1/3 0 2/3 0]]
[[0 0 0 0]
 [1 0 0 0]
 [0 1/4 0 0]
 [0 0 2/3 0]]
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-3-e8540957857a> in <module>
----> 1 erk = rk.loadRKM("SSP33"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha, beta=erk.beta) == erk

~/Software/nodepy/nodepy/runge_kutta_method.py in __init__(self, A, b, alpha, beta, name, shortname, description, mode, order)
    138                      'Inconsistent dimensions of Butcher arrays')
    139         elif shu_osher:
--> 140             A,b=shu_osher_to_butcher(alpha,beta)
    141         # Set Butcher arrays
    142         if len(np.shape(A))==2: self.A=A

~/Software/nodepy/nodepy/runge_kutta_method.py in shu_osher_to_butcher(alpha, beta)
   2558     if not np.all([np.size(alpha,0),np.size(beta,0),
   2559                     np.size(beta,1)]==[m+1,m+1,m]):
-> 2560         raise Exception('Inconsistent dimensions of Shu-Osher arrays')
   2561 
   2562     alph = snp.zeros( (m+1,m+1) )

Exception: Inconsistent dimensions of Shu-Osher arrays
```
In this PR:
```python
In [1]: from nodepy import *                                                                                     

In [2]: erk = rk.loadRKM("SSP22"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha
   ...: , beta=erk.beta) == erk                                                                                  
[[0 0]
 [1 0]
 [1/2 1/2]]
[[0 0]
 [1 0]
 [0 1/2]]
Out[2]: True

In [3]: erk.error_metrics()                                                                                      
main method has order 2
Out[3]: (sqrt(5)/12, 1/6, sqrt(3)/12, 1/8, 1)

In [4]: erk = rk.loadRKM("SSP33"); print(erk.alpha); print(erk.beta); rk.ExplicitRungeKuttaMethod(alpha=erk.alpha
   ...: , beta=erk.beta) == erk                                                                                  
[[0 0 0]
 [1 0 0]
 [3/4 1/4 0]
 [1/3 0 2/3]]
[[0 0 0]
 [1 0 0]
 [0 1/4 0]
 [0 0 2/3]]
Out[4]: True

In [5]: erk.error_metrics()                                                                                      
main method has order 3
embedded method has order 2
Out[5]: 
(sqrt(3)/24,
 1/24,
 sqrt(26465)/2880,
 1/30,
 0.0697758037030397,
 0.0624093761058714,
 1.23278818258423,
 1.16763472520512,
 0.670820393249938,
 0.500000000000000,
 1,
 0.59715065187922*sqrt(3),
 0.667634725205124)
```
It would be good to release a new version of NodePy including this bug fix.