### PR TITLE
fix LaTeX highlighting in `plot_stability_region` of LMMs

### DIFF
--- a/nodepy/linear_multistep_method.py
+++ b/nodepy/linear_multistep_method.py
@@ -234,9 +234,9 @@ class LinearMultistepMethod(GeneralLinearMethod):
             The region of absolute stability of a linear multistep method is
             the set
 
-            `\{ z \in C : \rho(\zeta) - z \sigma(zeta) \text{ satisfies the root condition} \}`
+            `\{ z \in C : \rho(\zeta) - z \sigma(\zeta) \text{ satisfies the root condition} \}`
 
-            where `\rho(zeta)` and `\sigma(zeta)` are the characteristic
+            where `\rho(\zeta)` and `\sigma(\zeta)` are the characteristic
             functions of the method.
 
             Also plots the boundary locus, which is


### PR DESCRIPTION
I noticed this when looking at the docs at https://nodepy.readthedocs.io/en/latest/lmm.html#stability.